### PR TITLE
Remove the restart prompt when saving settings to maslow.yaml file

### DIFF
--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -233,7 +233,6 @@ function build_control_from_pos(pos, extra) {
 
 function saveMaslowYaml() {
   SendGetHttp('/command?plain=' + encodeURIComponent("$CD=/maslow.yaml"));
-  restart_esp();
 }
 
 function build_HTML_setting_list(filter) {


### PR DESCRIPTION
While the fluidNC settings require a restart to take effect, the maslow settings for calibration actually don't, they can be applied right away. Since 99% of what folks are going to be changing in their settings is going to be calibration related I don't think we should encourage the restart because they they have to do the whole retract - extend thing again which we want to eliminate.

@ronlawrence3 Are you OK with this?