### PR TITLE
Move z axis buttons out to main window

### DIFF
--- a/www/css/tablet.css
+++ b/www/css/tablet.css
@@ -75,7 +75,7 @@ html {
   color: #7a7a7a;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 75% 25%;
+  grid-template-columns: 70% 30%;
 }
 
 .maslow-grid-container {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -395,7 +395,6 @@ function initUI() {
   if (typeof id('FW_VERSION') != 'undefined') id('FW_VERSION').innerHTML = fw_version
   // Get the element with id="defaultOpen" and click on it
   id('tablettablink').click()
-  onReportType({ value: 'auto' })
 
   if (typeof id('grblcontroltablink') !== 'undefined') {
     id('grblcontroltablink').click()
@@ -405,6 +404,8 @@ function initUI() {
   console.log(JSON.stringify(translated_list))
   //endRemoveIf(production)
   initUI_2()
+
+  setTimeout(tryAutoReport, 500); //Not sure why this needs a delay but it seems like a hack
 }
 
 function initUI_2() {

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -1164,7 +1164,6 @@ window.addEventListener('keydown', handleKeyDown)
 window.addEventListener('keyup', handleKeyUp)
 
 numpad.attach({ target: 'disM', axis: 'D' })
-numpad.attach({ target: 'disZ', axis: 'Z' })
 //numpad.attach({target: "wpos-y", axis: "Y"});
 //numpad.attach({target: "wpos-z", axis: "Z"});
 //numpad.attach({target: "wpos-a", axis: "A"});
@@ -1219,10 +1218,6 @@ function fullscreenIfMobile() {
   }
 }
 
-function showZaxisPopup() {
-  document.getElementById('z-axis-popup').style.display = 'block'
-}
-
 function showCalibrationPopup() {
   document.getElementById('calibration-popup').style.display = 'block'
 }
@@ -1251,13 +1246,6 @@ function homeZ() {
 }
 
 document.addEventListener('click', function (event) {
-  if (
-    !document.getElementById('z-axis-popup').contains(event.target) &&
-    !document.getElementById('zBtn').contains(event.target) &&
-    !document.getElementById('numPad').contains(event.target)
-  ) {
-    document.getElementById('z-axis-popup').style.display = 'none'
-  }
   if (
     !document.getElementById('calibration-popup').contains(event.target) &&
     !document.getElementById('calibrationBTN').contains(event.target) &&

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -218,9 +218,6 @@ sendMove = function (cmd) {
   }
 
   var distance = Number(id('disM').innerText) || 0
-  if (cmd.includes('Z')) {
-    distance = Number(id('disZ').innerText) || 0
-  }
 
   var fn = {
     G28: function () {

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -488,7 +488,7 @@ function tabletShowMessage(msg, collecting) {
   if (msg.startsWith('error:')) {
     const msgExtra = {
       "8": " - Command requires idle state. Unlock machine?",
-      "152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Try restarting",
+      "152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Turning off and back on again can often fix this issue.",
       "153": " - Configuration is invalid. ESP32 probably did a panic reset. Config changes cannot be saved. Try restarting",
     };
 

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -192,6 +192,7 @@ checkHomed = function () {
 }
 
 sendMove = function (cmd) {
+  console.log("Send move called");
   tabletClick()
   var jog = function (params) {
     params = params || {}
@@ -218,6 +219,10 @@ sendMove = function (cmd) {
   }
 
   var distance = Number(id('disM').innerText) || 0
+
+  if (cmd.includes('Z') && distance > 75) {
+    alert("Can't move the z-axis that far");
+  }
 
   var fn = {
     G28: function () {

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -19,7 +19,16 @@
           <div class="maslow-grid-item maslow-grid-item-btn" onclick="sendMove('X-Y+')" style="background-color: #b69fcb;"><canvas id="tlBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y+')"><canvas id="upBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y+')"><canvas id="trBtn" style="width: 100%; height: 100%"></canvas></div>
-          <div class="maslow-grid-item maslow-grid-item-btn"></div>
+          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4; font-size: 1vw; color: #337ab7; display: flex;flex-direction: column;"
+            onclick="loadCornerValues(); openModal('calibration-popup');" id="calibrationBTN" >
+            <svg height="32" width="32" viewBox="0 0 48 48" fill="currentColor">
+              <g>
+                <path d="M24,11c-7.2,0-13,5.8-13,13c0,7.2,5.8,13,13,13c7.2,0,13-5.8,13-13C37,16.8,31.2,11,24,11z M24,35c-6.1,0-11-4.9-11-11   s4.9-11,11-11s11,4.9,11,11S30.1,35,24,35z" />
+                <path d="M44,20h-2.4c-0.5-2.1-1.3-4-2.3-5.6l1.6-1.8c1.2-1.2,1.2-3,0-4.2L39.5,7c-1.2-1.2-3.1-1.2-4.2,0l-1.8,1.8   c-1.8-1.2-3.6-1.9-5.6-2.3V4c0-1.7-1.3-3-3-3h-2c-1.7,0-3,1.3-3,3v2.5c-1.9,0.4-3.8,1.2-5.6,2.3l-1.7-1.7c-1.2-1.2-3-1.2-4.2,0   L7,8.5c-0.6,0.6-0.9,1.3-0.9,2.1s0.3,1.5,0.9,2.1l1.8,1.7c-1.1,1.8-1.9,3.6-2.3,5.6H4c-1.7,0-3,1.3-3,3v2c0,1.7,1.3,3,3,3h2.5   c0.4,1.9,1.2,3.8,2.4,5.6l-1.7,1.8c-1.2,1.2-1.2,3,0,4.2L8.5,41c1.2,1.2,3,1.2,4.2,0l1.7-1.8c1.8,1.1,3.6,1.9,5.6,2.3V44   c0,1.7,1.3,3,3,3h2c1.7,0,3-1.3,3-3v-2.4c2.1-0.5,3.9-1.3,5.6-2.3l1.7,1.6c1.2,1.2,3,1.2,4.2,0l1.4-1.4c1.2-1.2,1.2-3,0-4.2   l-1.7-1.7c1.2-1.8,1.9-3.6,2.3-5.6H44c1.7,0,3-1.3,3-3v-2C47,21.3,45.7,20,44,20z M45,25c0,0.6-0.4,1-1,1h-4.2l-0.1,0.8   c-0.4,2.2-1.2,4.3-2.6,6.3l-0.5,0.7l2.9,2.9c0.2,0.2,0.3,0.4,0.3,0.7c0,0.3-0.1,0.5-0.3,0.7l-1.4,1.4c-0.4,0.4-1,0.4-1.4,0   l-2.9-2.8l-0.7,0.5c-1.8,1.3-3.9,2.2-6.3,2.6L26,40v4c0,0.6-0.4,1-1,1h-2c-0.6,0-1-0.4-1-1v-4.2l-0.8-0.1c-2.2-0.4-4.3-1.2-6.3-2.6   l-0.7-0.5l-2.9,3c-0.4,0.4-1,0.4-1.4,0l-1.4-1.4c-0.4-0.4-0.4-1,0-1.4l2.9-3l-0.5-0.7c-1.4-2-2.3-4.1-2.6-6.3L8.2,26H4   c-0.6,0-1-0.4-1-1v-2c0-0.6,0.4-1,1-1h4.2l0.1-0.8c0.4-2.2,1.2-4.3,2.6-6.3l0.5-0.7l-3-2.9c-0.2-0.2-0.3-0.4-0.3-0.7   s0.1-0.5,0.3-0.7l1.4-1.4c0.4-0.4,1-0.4,1.4,0l2.9,2.9l0.7-0.5c1.9-1.4,4.1-2.3,6.3-2.6l0.8-0.1V4c0-0.6,0.4-1,1-1h2   c0.6,0,1,0.4,1,1v4.2l0.8,0.1c2.2,0.4,4.3,1.2,6.3,2.6l0.7,0.5l3-3c0.4-0.4,1-0.4,1.4,0l1.4,1.4c0.4,0.4,0.4,1,0,1.4l-2.7,3   l0.5,0.7c1.2,1.8,2.1,3.9,2.6,6.3L40,22h4c0.6,0,1,0.4,1,1V25z" />
+              </g>
+            </svg>
+            <span>Setup</span>
+          </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
             onclick="sendMove('Z-');" id="zDown">
             <svg width="32" height="32" viewBox="0 0 38 38">
@@ -31,16 +40,8 @@
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('X-')"><canvas id="lBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" onclick="moveHome()"><canvas id="hBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('X+')"><canvas id="rBtn" style="width: 100%; height: 100%"></div>
-          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4; font-size: 1vw; color: #337ab7; display: flex;flex-direction: column;"
-            onclick="loadCornerValues(); openModal('calibration-popup');" id="calibrationBTN" >
-            <svg height="32" width="32" viewBox="0 0 48 48" fill="currentColor">
-              <g>
-                <path d="M24,11c-7.2,0-13,5.8-13,13c0,7.2,5.8,13,13,13c7.2,0,13-5.8,13-13C37,16.8,31.2,11,24,11z M24,35c-6.1,0-11-4.9-11-11   s4.9-11,11-11s11,4.9,11,11S30.1,35,24,35z" />
-                <path d="M44,20h-2.4c-0.5-2.1-1.3-4-2.3-5.6l1.6-1.8c1.2-1.2,1.2-3,0-4.2L39.5,7c-1.2-1.2-3.1-1.2-4.2,0l-1.8,1.8   c-1.8-1.2-3.6-1.9-5.6-2.3V4c0-1.7-1.3-3-3-3h-2c-1.7,0-3,1.3-3,3v2.5c-1.9,0.4-3.8,1.2-5.6,2.3l-1.7-1.7c-1.2-1.2-3-1.2-4.2,0   L7,8.5c-0.6,0.6-0.9,1.3-0.9,2.1s0.3,1.5,0.9,2.1l1.8,1.7c-1.1,1.8-1.9,3.6-2.3,5.6H4c-1.7,0-3,1.3-3,3v2c0,1.7,1.3,3,3,3h2.5   c0.4,1.9,1.2,3.8,2.4,5.6l-1.7,1.8c-1.2,1.2-1.2,3,0,4.2L8.5,41c1.2,1.2,3,1.2,4.2,0l1.7-1.8c1.8,1.1,3.6,1.9,5.6,2.3V44   c0,1.7,1.3,3,3,3h2c1.7,0,3-1.3,3-3v-2.4c2.1-0.5,3.9-1.3,5.6-2.3l1.7,1.6c1.2,1.2,3,1.2,4.2,0l1.4-1.4c1.2-1.2,1.2-3,0-4.2   l-1.7-1.7c1.2-1.8,1.9-3.6,2.3-5.6H44c1.7,0,3-1.3,3-3v-2C47,21.3,45.7,20,44,20z M45,25c0,0.6-0.4,1-1,1h-4.2l-0.1,0.8   c-0.4,2.2-1.2,4.3-2.6,6.3l-0.5,0.7l2.9,2.9c0.2,0.2,0.3,0.4,0.3,0.7c0,0.3-0.1,0.5-0.3,0.7l-1.4,1.4c-0.4,0.4-1,0.4-1.4,0   l-2.9-2.8l-0.7,0.5c-1.8,1.3-3.9,2.2-6.3,2.6L26,40v4c0,0.6-0.4,1-1,1h-2c-0.6,0-1-0.4-1-1v-4.2l-0.8-0.1c-2.2-0.4-4.3-1.2-6.3-2.6   l-0.7-0.5l-2.9,3c-0.4,0.4-1,0.4-1.4,0l-1.4-1.4c-0.4-0.4-0.4-1,0-1.4l2.9-3l-0.5-0.7c-1.4-2-2.3-4.1-2.6-6.3L8.2,26H4   c-0.6,0-1-0.4-1-1v-2c0-0.6,0.4-1,1-1h4.2l0.1-0.8c0.4-2.2,1.2-4.3,2.6-6.3l0.5-0.7l-3-2.9c-0.2-0.2-0.3-0.4-0.3-0.7   s0.1-0.5,0.3-0.7l1.4-1.4c0.4-0.4,1-0.4,1.4,0l2.9,2.9l0.7-0.5c1.9-1.4,4.1-2.3,6.3-2.6l0.8-0.1V4c0-0.6,0.4-1,1-1h2   c0.6,0,1,0.4,1,1v4.2l0.8,0.1c2.2,0.4,4.3,1.2,6.3,2.6l0.7,0.5l3-3c0.4-0.4,1-0.4,1.4,0l1.4,1.4c0.4,0.4,0.4,1,0,1.4l-2.7,3   l0.5,0.7c1.2,1.8,2.1,3.9,2.6,6.3L40,22h4c0.6,0,1,0.4,1,1V25z" />
-              </g>
-            </svg>
-            <span>Setup</span>
-          </div>
+          <div class="maslow-grid-item maslow-grid-item-btn"></div>
+
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;"
             onmousedown="zeroAxis('Z');" onmouseup="refreshGcode();">Define Z Home</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X-Y-')"> <canvas id="blBtn" style="width: 100%; height: 100%"></canvas> </div>
@@ -113,22 +114,6 @@
     </div>
 
   </div>
-
-    <div id="z-axis-popup" class="calibration-modal-container" onclick="hideModal('z-axis-popup')">
-      <div class="calibration-modal-content" onclick="event.stopPropagation();">
-          <div class="calibration-modal-button-container">
-              <div class="buttons-row">
-                <div class="calibration-modal-info" id = "disZ"> 1.00</div>
-                <button class="calibration-modal-button" onclick="sendMove('Z+')"> Up</button>
-              </div>
-              <div class="buttons-row">
-                <button class="calibration-modal-button" onclick="zeroAxis('Z')"> Define Home</button>
-                <button class="calibration-modal-button" onclick="sendMove('Z-')"> Down</button>
-              </div>
-
-            </div>
-      </div>
-    </div>
 
     <div id="calibration-popup" class="calibration-modal-container" onclick="hideModal('calibration-popup')">
       <div class="calibration-modal-content" onclick="event.stopPropagation();">

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -9,7 +9,7 @@
       <div class = "tablettab-controls-wrapper">
         <div style="grid-template-columns: 20% 20% 20% 20% 20%;" class="maslow-grid-container tablettab-controls-item">
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
-            onclick="onclick=sendMove('Z+');" id="zUP">
+            onclick="sendMove('Z+');" id="zUp">
             <svg width="32" height="32" viewBox="0 0 38 38">
               <polygon fill="currentColor" points="10.319 5.525 17.833 13.039 2.805 13.039 10.319 5.525" />
               <rect fill="currentColor" height="2.5" transform="translate(31.899 11.262) rotate(90)" width="21.79" x="-0.576" y="20.33" />
@@ -21,7 +21,7 @@
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y+')"><canvas id="trBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
-            onclick="onclick=sendMove('Z-');" id="zBtn3">
+            onclick="sendMove('Z-');" id="zDown">
             <svg width="32" height="32" viewBox="0 0 38 38">
               <polygon fill="currentColor" points="27.681 32.475 35.195 24.961 20.167 24.961 27.681 32.475" />
               <rect fill="currentColor" height="2.5" transform="translate(11.262 44.101) rotate(-90)" width="21.79" x="16.786" y="15.17" />

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -19,20 +19,10 @@
           <div class="maslow-grid-item maslow-grid-item-btn" onclick="sendMove('X-Y+')" style="background-color: #b69fcb;"><canvas id="tlBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y+')"><canvas id="upBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y+')"><canvas id="trBtn" style="width: 100%; height: 100%"></canvas></div>
-          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #337ab7; color: white; height: 50px;display: flex;flex-direction: column;"
-            onclick="files_select_upload()">
-            <svg width="1.3em" height="1.2em" viewBox="0 0 1792 1792" fill="currentColor">
-              <g>
-                <path d="M1344 1472q0-26-19-45t-45-19-45 19-19 45 19 45 45 19 45-19 19-45zm256 0q0-26-19-45t-45-19-45 19-19 45 19 45 45 19 45-19 19-45zm128-224v320q0 40-28 68t-68 28h-1472q-40 0-68-28t-28-68v-320q0-40 28-68t68-28h427q21 56 70.5 92t110.5 36h256q61 0 110.5-36t70.5-92h427q40 0 68 28t28 68zm-325-648q-17 40-59 40h-256v448q0 26-19 45t-45 19h-256q-26 0-45-19t-19-45v-448h-256q-42 0-59-40-17-39 14-69l448-448q18-19 45-19t45 19l448 448q31 30 14 69z"/>
-              </g>
-            </svg>
-            <span>Upload GCode</span>
-          </div>
+          <div class="maslow-grid-item maslow-grid-item-btn"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
-            onclick="openModal('z-axis-popup');" id="zBtn3">
+            onclick="onclick=sendMove('Z-');" id="zBtn3">
             <svg width="32" height="32" viewBox="0 0 38 38">
-              <polygon fill="currentColor" points="10.319 5.525 17.833 13.039 2.805 13.039 10.319 5.525" />
-              <rect fill="currentColor" height="2.5" transform="translate(31.899 11.262) rotate(90)" width="21.79" x="-0.576" y="20.33" />
               <polygon fill="currentColor" points="27.681 32.475 35.195 24.961 20.167 24.961 27.681 32.475" />
               <rect fill="currentColor" height="2.5" transform="translate(11.262 44.101) rotate(-90)" width="21.79" x="16.786" y="15.17" />
             </svg>
@@ -52,7 +42,7 @@
             <span>Setup</span>
           </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;"
-            onmousedown="zeroAxis('X');zeroAxis('Y');" onmouseup="refreshGcode();">Define Home</div>
+            onmousedown="zeroAxis('Z');" onmouseup="refreshGcode();">Define Z Home</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X-Y-')"> <canvas id="blBtn" style="width: 100%; height: 100%"></canvas> </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y-')"><canvas id="dnBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y-')"> <canvas id="brBtn" style="width: 100%; height: 100%"></canvas> </div>
@@ -72,12 +62,21 @@
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" id="units" title="Toggle Units"
             onclick="toggleUnits()">mm</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;"
-            onmousedown="zeroAxis('X');zeroAxis('Y');" onmouseup="refreshGcode();">Define Home</div>
+            onmousedown="zeroAxis('X');zeroAxis('Y');" onmouseup="refreshGcode();">Define XY Home</div>
         </div>
-        <div class="maslow-grid-container tablettab-controls-item" style="height: 60px;">
+        <div style="grid-template-columns: 80% 20%;" class="maslow-grid-container tablettab-controls-item" style="height: 60px;">
           <select class="form-control" id="filelist" onchange="selectFile()">
             <option>Load File...</option>
           </select>
+          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #337ab7; color: white; height: 50px;display: flex;flex-direction: column;"
+          onclick="files_select_upload()">
+          <svg width="1.3em" height="1.2em" viewBox="0 0 1792 1792" fill="currentColor">
+            <g>
+              <path d="M1344 1472q0-26-19-45t-45-19-45 19-19 45 19 45 45 19 45-19 19-45zm256 0q0-26-19-45t-45-19-45 19-19 45 19 45 45 19 45-19 19-45zm128-224v320q0 40-28 68t-68 28h-1472q-40 0-68-28t-28-68v-320q0-40 28-68t68-28h427q21 56 70.5 92t110.5 36h256q61 0 110.5-36t70.5-92h427q40 0 68 28t28 68zm-325-648q-17 40-59 40h-256v448q0 26-19 45t-45 19h-256q-26 0-45-19t-19-45v-448h-256q-42 0-59-40-17-39 14-69l448-448q18-19 45-19t45 19l448 448q31 30 14 69z"/>
+            </g>
+          </svg>
+          <span>Upload GCode</span>
+          </div>
         </div>
         <div class="maslow-grid-container tablettab-controls-item" style="grid-template-columns: 33% 33% 33%;">
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #4aa85c;" onclick="doPlayButton()">

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -7,10 +7,16 @@
         </textarea>
       </div>
       <div class = "tablettab-controls-wrapper">
-        <div style="grid-template-columns: 25% 25% 25% 25%;" class="maslow-grid-container tablettab-controls-item">
-          <div class="maslow-grid-item maslow-grid-item-btn" onclick="sendMove('X-Y+')" style="background-color: #b69fcb;">
-            <canvas id="tlBtn" style="width: 100%; height: 100%"></canvas>
+        <div style="grid-template-columns: 20% 20% 20% 20% 20%;" class="maslow-grid-container tablettab-controls-item">
+          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
+            onclick="onclick=sendMove('Z+');" id="zUP">
+            <svg width="32" height="32" viewBox="0 0 38 38">
+              <polygon fill="currentColor" points="10.319 5.525 17.833 13.039 2.805 13.039 10.319 5.525" />
+              <rect fill="currentColor" height="2.5" transform="translate(31.899 11.262) rotate(90)" width="21.79" x="-0.576" y="20.33" />
+            </svg>
+            Z
           </div>
+          <div class="maslow-grid-item maslow-grid-item-btn" onclick="sendMove('X-Y+')" style="background-color: #b69fcb;"><canvas id="tlBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y+')"><canvas id="upBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y+')"><canvas id="trBtn" style="width: 100%; height: 100%"></canvas></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #337ab7; color: white; height: 50px;display: flex;flex-direction: column;"
@@ -21,6 +27,16 @@
               </g>
             </svg>
             <span>Upload GCode</span>
+          </div>
+          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
+            onclick="openModal('z-axis-popup');" id="zBtn3">
+            <svg width="32" height="32" viewBox="0 0 38 38">
+              <polygon fill="currentColor" points="10.319 5.525 17.833 13.039 2.805 13.039 10.319 5.525" />
+              <rect fill="currentColor" height="2.5" transform="translate(31.899 11.262) rotate(90)" width="21.79" x="-0.576" y="20.33" />
+              <polygon fill="currentColor" points="27.681 32.475 35.195 24.961 20.167 24.961 27.681 32.475" />
+              <rect fill="currentColor" height="2.5" transform="translate(11.262 44.101) rotate(-90)" width="21.79" x="16.786" y="15.17" />
+            </svg>
+            Z
           </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('X-')"><canvas id="lBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" onclick="moveHome()"><canvas id="hBtn" style="width: 100%; height: 100%"></div>
@@ -35,6 +51,8 @@
             </svg>
             <span>Setup</span>
           </div>
+          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;"
+            onmousedown="zeroAxis('X');zeroAxis('Y');" onmouseup="refreshGcode();">Define Home</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X-Y-')"> <canvas id="blBtn" style="width: 100%; height: 100%"></canvas> </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y-')"><canvas id="dnBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y-')"> <canvas id="brBtn" style="width: 100%; height: 100%"></canvas> </div>
@@ -48,6 +66,7 @@
             </svg>
             Z
           </div>
+          <div class="maslow-grid-item maslow-grid-item-btn"></div>
           <div class="maslow-grid-item maslow-grid-item-btn">Dist To Move:</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" id="disM">100</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" id="units" title="Toggle Units"

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -46,23 +46,15 @@
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X-Y-')"> <canvas id="blBtn" style="width: 100%; height: 100%"></canvas> </div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #9d88c0;" onclick="sendMove('Y-')"><canvas id="dnBtn" style="width: 100%; height: 100%"></div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #b69fcb;" onclick="sendMove('X+Y-')"> <canvas id="brBtn" style="width: 100%; height: 100%"></canvas> </div>
-          <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;; color: #337ab7"
-            onclick="openModal('z-axis-popup');" id="zBtn">
-            <svg width="32" height="32" viewBox="0 0 38 38">
-              <polygon fill="currentColor" points="10.319 5.525 17.833 13.039 2.805 13.039 10.319 5.525" />
-              <rect fill="currentColor" height="2.5" transform="translate(31.899 11.262) rotate(90)" width="21.79" x="-0.576" y="20.33" />
-              <polygon fill="currentColor" points="27.681 32.475 35.195 24.961 20.167 24.961 27.681 32.475" />
-              <rect fill="currentColor" height="2.5" transform="translate(11.262 44.101) rotate(-90)" width="21.79" x="16.786" y="15.17" />
-            </svg>
-            Z
-          </div>
           <div class="maslow-grid-item maslow-grid-item-btn"></div>
+          
           <div class="maslow-grid-item maslow-grid-item-btn">Dist To Move:</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" id="disM">100</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;" id="units" title="Toggle Units"
             onclick="toggleUnits()">mm</div>
           <div class="maslow-grid-item maslow-grid-item-btn" style="background-color: #f2f0e4;"
             onmousedown="zeroAxis('X');zeroAxis('Y');" onmouseup="refreshGcode();">Define XY Home</div>
+          <div class="maslow-grid-item maslow-grid-item-btn"></div>
         </div>
         <div style="grid-template-columns: 80% 20%;" class="maslow-grid-container tablettab-controls-item" style="height: 60px;">
           <select class="form-control" id="filelist" onchange="selectFile()">


### PR DESCRIPTION
Rearranges the UI to remove the z-axis popup and instead puts those buttons on the main window.

<img width="479" alt="image" src="https://github.com/BarbourSmith/ESP3D-WEBUI/assets/9359447/379ef507-1275-4424-b177-d214ce560175">

The empty spaces on the right will be used to add buttons for calibration later.