### PR TITLE
Use the browser size to determin the preview resolution

### DIFF
--- a/www/js/toolpath-displayer.js
+++ b/www/js/toolpath-displayer.js
@@ -3,8 +3,10 @@
 var root = window;
 
 var canvas = id("small-toolpath");
-canvas.width = 800;
-canvas.height = 400;
+const scale = window.devicePixelRatio;
+const width = window.innerWidth; 
+canvas.width = width * scale;
+canvas.height = (width / 2) * scale;
 var tp = canvas.getContext("2d", { willReadFrequently: true });
 var tpRect;
 


### PR DESCRIPTION
This will change the current canvas resolution from always being 800x400 to instead being determined based on the device browser size. Using the browser window width and scaling that with the device pixel ratio to set the canvas width, and using half that resolution for the height.