### PR TITLE
Remove projection again

### DIFF
--- a/www/js/calculatesCalibrationStuff.js
+++ b/www/js/calculatesCalibrationStuff.js
@@ -508,8 +508,8 @@ function findMaxFitness(measurements) {
     initialGuess
   }, true);
 
-  //Project the measurements into the XY plane
-  measurements = projectMeasurements(measurements);
+  //Project the measurements into the XY plane...this is now done on the firmware side
+  //measurements = projectMeasurements(measurements);
 
   let currentGuess = JSON.parse(JSON.stringify(initialGuess));
   let stagnantCounter = 0;


### PR DESCRIPTION
Projection has moved into the firmware in https://github.com/BarbourSmith/FluidNC/pull/160 and so now we do not need it in the index.html file anymore.