### PR TITLE
Standardize `error_code` and `alertdlg`

### DIFF
--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -123,16 +123,16 @@ function SPIFFSsuccess(response) {
     SPIFFSdispatchfilestatus(jsonresponse);
 }
 
-function SPIFFSfailed(errorcode, response) {
+function SPIFFSfailed(error_code, response) {
     id('SPIFFS_loader').style.visibility = "hidden";
     displayBlock('refreshSPIFFSbtn');
     displayBlock('refreshSPIFFSbtn');
-    alertdlg(translate_text_item("Error"), "Error " + errorcode + " : " + response);
-    console.log("Error " + errorcode + " : " + response);
+    alertdlg(translate_text_item("Error"), stdErrMsg(error_code, response));
+    conErr(error_code, response);
 }
 
 function SPIFFSbutton(filename, method, btn_class, icon) {
-       return "<td width='0%'  style='vertical-align:middle'><button class=\"btn " + btn_class + " btn-xs\" style='padding: 5px 5px 0px 5px;' onclick=\"" + method + "('" + filename + "')\">" + get_icon_svg(icon) + "</button></td>";
+    return "<td width='0%'  style='vertical-align:middle'><button class=\"btn " + btn_class + " btn-xs\" style='padding: 5px 5px 0px 5px;' onclick=\"" + method + "('" + filename + "')\">" + get_icon_svg(icon) + "</button></td>";
 }
 
 function SPIFFSdispatchfilestatus(jsonresponse) {
@@ -149,7 +149,7 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
         var previouspath = SPIFFS_currentpath.slice(0, pos + 1);
         content += "<tr style='cursor:pointer;' onclick=\"SPIFFS_currentpath='" + previouspath + "'; SPIFFSSendCommand('list','all');\"><td >" + get_icon_svg("level-up") + "</td><td colspan='4'> Up..</td></tr>";
     }
-    jsonresponse.files.sort(function(a, b) {
+    jsonresponse.files.sort(function (a, b) {
         return compareStrings(a.name, b.name);
     });
 
@@ -275,21 +275,21 @@ function SPIFFSUploadsuccess(response) {
     SPIFFSdispatchfilestatus(jsonresponse);
 }
 
-function SPIFFSUploadfailed(errorcode, response) {
+function SPIFFSUploadfailed(error_code, response) {
     displayBlock('SPIFFS-select_form');
     displayNone('SPIFFS_prg');
     displayBlock('SPIFFS_uploadbtn');
     id('uploadSPIFFSmsg').innerHTML = "";
     displayNone("uploadSPIFFSmsg");
     displayBlock('refreshSPIFFSbtn');
-    console.log("Error " + errorcode + " : " + response);
-    if (esp_error_code !=0){
-         alertdlg (translate_text_item("Error") + " (" + esp_error_code + ")", esp_error_message);
-         id('SPIFFS_status').innerHTML = translate_text_item("Error : ") + esp_error_message;
-         esp_error_code = 0;
+    conErr(stdErrMsg(error_code, response));
+    if (esp_error_code != 0) {
+        alertdlg(translate_text_item("Error"), stdErrMsg(`(${esp_error_code})`, esp_error_message));
+        id('SPIFFS_status').innerHTML = translate_text_item("Error : ") + esp_error_message;
+        esp_error_code = 0;
     } else {
-        alertdlg (translate_text_item("Error"), "Error " + errorcode + " : " + response);
-        id('SPIFFS_status').innerHTML = translate_text_item("Upload failed : ") + errorcode;
+        alertdlg(translate_text_item("Error"), stdErrMsg(error_code, response));
+        id('SPIFFS_status').innerHTML = stdErrMsg(error_code, response, translate_text_item("Upload failed"));
     }
     SPIFFS_upload_ongoing = false;
     refreshSPIFFS();

--- a/www/js/commands.js
+++ b/www/js/commands.js
@@ -132,10 +132,10 @@ function SendCustomCommandSuccess(response) {
 }
 
 function SendCustomCommandFailed(error_code, response) {
-    if (error_code == 0) {
-        Monitor_output_Update(translate_text_item("Connection error") + "\n");
-    } else {
-         Monitor_output_Update(translate_text_item("Error : ") + error_code + " :" + decode_entitie(response) + "\n");
-    }
-    console.log("cmd Error " + error_code + " :" + decode_entitie(response));
+    const errMsg = (error_code == 0)
+        ? translate_text_item("Connection error")
+        : stdErrMsg(error_code, decode_entitie(response), translate_text_item("Error"));
+    Monitor_output_Update(errMsg + "\n");
+
+    conErr(error_code, decode_entitie(response), "cmd Error");
 }

--- a/www/js/config.js
+++ b/www/js/config.js
@@ -391,10 +391,10 @@ function inline_help(label) {
 }
 
 function setESPconfigfailed(error_code, response) {
-    alertdlg(translate_text_item("Set failed"), "Error " + error_code + " :" + response);
-    console.log("Error " + error_code + " :" + response);
-    var prefix = "";
-    if (config_lastindex_is_override) prefix = "_override";
+    const errMsg = stdErrMsg(error_code, response);
+    alertdlg(translate_text_item("Set failed"), errMsg);
+    conErr(errMsg);
+    const prefix = (config_lastindex_is_override) ? "_override" : "";
     id('btn_config_' + prefix + config_lastindex).className = "btn btn-danger";
     id('icon_config_' + prefix + config_lastindex).className = "form-control-feedback has-error ico_feedback";
     id('icon_config_' + prefix + config_lastindex).innerHTML = get_icon_svg("remove");
@@ -414,9 +414,9 @@ function getESPconfigSuccess(response) {
 }
 
 function getESPconfigfailed(error_code, response) {
-    console.log("Error " + error_code + " :" + response);
+    conErr(error_code, response);
     displayNone('config_loader');
     displayBlock('config_status');
-    id('config_status').innerHTML = translate_text_item("Failed:") + error_code + " " + response;
+    id('config_status').innerHTML = stdErrMsg(error_code, response, translate_text_item("Failed"));
     displayBlock('config_refresh_btn');
 }

--- a/www/js/connectdlg.js
+++ b/www/js/connectdlg.js
@@ -112,11 +112,11 @@ function connectsuccess(response) {
     }
 }
 
-function connectfailed(errorcode, response) {
+function connectfailed(error_code, response) {
     displayBlock('connectbtn');
     displayBlock('failed_connect_msg');
     displayNone('connecting_msg');
-    console.log("Fw identification error " + errorcode + " : " + response);
+    conErr(error_code, response, "Fw identification error");
 }
 
 function retryconnect() {

--- a/www/js/controls.js
+++ b/www/js/controls.js
@@ -71,8 +71,8 @@ function processMacroGetSuccess(response) {
     else Macro_build_list("");
 }
 
-function processMacroGetFailed(errorcode, response) {
-    console.log("Error " + errorcode + " : " + response);
+function processMacroGetFailed(error_code, response) {
+    conErr(error_code, response);
     Macro_build_list("");
 }
 

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -78,19 +78,19 @@ function formatFileSize(size) {
         return size;
     }
     if (nSize > 1000000000000) {
-        nFix = nSize/1000000000000;
+        nFix = nSize / 1000000000000;
         return nFix.toFixed(2) + " TB";
     }
     if (nSize > 1000000000) {
-        nFix = nSize/1000000000;
+        nFix = nSize / 1000000000;
         return nFix.toFixed(2) + " GB";
     }
     if (nSize > 1000000) {
-        nFix = nSize/1000000;
+        nFix = nSize / 1000000;
         return nFix.toFixed(2) + " MB";
     }
     if (nSize > 1000) {
-        nFix = nSize/1000;
+        nFix = nSize / 1000;
         return nFix.toFixed(2) + " KB";
     }
     return nSize + " B";
@@ -126,9 +126,9 @@ function files_build_file_line(index) {
         if (is_clickable) {
             content += "style='cursor:pointer;' onclick='files_click_file(" + index + ")' ";
         }
-        var size= formatFileSize(entry.size);
-        if (entry.isdir)size="";
-        content += ">" +  size + "</div>";
+        var size = formatFileSize(entry.size);
+        if (entry.isdir) size = "";
+        content += ">" + size + "</div>";
         content += "<div class='" + timecol + "'";
         if (is_clickable) {
             content += "style='cursor:pointer;' onclick='files_click_file(" + index + ")' ";
@@ -333,13 +333,13 @@ function files_showdeletebutton(index) {
     return true;
 }
 
-function cleanpath(path){
+function cleanpath(path) {
     var p = path;
     p.trim();
-    if (p[0]!='/')p="/"+p;
-    if (p!="/"){
-        if (p.endsWith("/")){
-            p = p .substr(0, p.length - 1);
+    if (p[0] != '/') p = "/" + p;
+    if (p != "/") {
+        if (p.endsWith("/")) {
+            p = p.substr(0, p.length - 1);
         }
     }
     return p;
@@ -349,15 +349,15 @@ function files_refreshFiles(path, usecache) {
     //console.log("refresh requested " + path);
     var cmdpath = path;
     files_currentPath = path;
-    if (current_source != last_source){
+    if (current_source != last_source) {
         files_currentPath = "/";
-        path="/";
+        path = "/";
         last_source = current_source;
     }
-    if ((current_source==tft_sd) || (current_source==tft_usb)){
-     displayNone('print_upload_btn');
+    if ((current_source == tft_sd) || (current_source == tft_usb)) {
+        displayNone('print_upload_btn');
     } else {
-     displayBlock('print_upload_btn');
+        displayBlock('print_upload_btn');
     }
     if (typeof usecache === 'undefined') usecache = false;
     id('files_currentPath').innerHTML = files_currentPath;
@@ -463,23 +463,27 @@ function files_list_success(response_text) {
     files_build_display_filelist();
 }
 
+/** Shows an alert dialog for the ESP error, and then clears the ESP error_code */
+const alertEspError = () => {
+    alertdlg(translate_text_item("Error"), stdErrMsg(`(${esp_error_code})`, esp_error_message));
+    esp_error_code = 0;
+}
+
 function files_list_failed(error_code, response) {
     displayBlock('files_navigation_buttons');
-    if (esp_error_code !=0){
-         alertdlg (translate_text_item("Error") + " (" + esp_error_code + ")", esp_error_message);
-         esp_error_code = 0;
+    if (esp_error_code != 0) {
+        alertEspError();
     } else {
-        alertdlg (translate_text_item("Error"), translate_text_item("No connection"));
+        alertdlg(translate_text_item("Error"), translate_text_item("No connection"));
     }
     files_build_display_filelist(false);
 }
 
 function files_directSD_upload_failed(error_code, response) {
-    if (esp_error_code !=0){
-         alertdlg (translate_text_item("Error") + " (" + esp_error_code + ")", esp_error_message);
-         esp_error_code = 0;
+    if (esp_error_code != 0) {
+        alertEspError();
     } else {
-        alertdlg (translate_text_item("Error"), translate_text_item("Upload failed"));
+        alertdlg(translate_text_item("Error"), translate_text_item("Upload failed"));
     }
     displayNone('files_uploading_msg');
     displayBlock('files_navigation_buttons');

--- a/www/js/http.js
+++ b/www/js/http.js
@@ -21,14 +21,14 @@ function http_resultfn(response_text) {
     process_cmd();
 }
 
-function http_errorfn(errorcode, response_text) {
+function http_errorfn(error_code, response_text) {
     var fn = http_cmd_list[0].errorfn;
     if ((http_cmd_list.length > 0) && (typeof http_cmd_list[0].errorfn != 'undefined') && http_cmd_list[0].errorfn != null) {
-        if (errorcode == 401) {
+        if (error_code == 401) {
             logindlg();
             console.log("Authentication issue pls log");
         }
-        http_cmd_list[0].errorfn(errorcode, response_text);
+        http_cmd_list[0].errorfn(error_code, response_text);
     } //else console.log ("No errorfn");
     http_cmd_list.shift();
     processing_cmd = false;

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -39,11 +39,10 @@ function login_password_OnKeyUp(event) {
 }
 
 
-function loginfailed(errorcode, response_text) {
+function loginfailed(error_code, response_text) {
     var response = JSON.parse(response_text);
-    if (typeof(response.status) !== 'undefined') id('login_title').innerHTML = translate_text_item(response.status);
-    else id('login_title').innerHTML = translate_text_item("Identification invalid!");
-    console.log("Error " + errorcode + " : " + response_text);
+    id('login_title').innerHTML = translate_text_item(response.status || "Identification invalid!");
+    conErr(error_code, response_text);
     displayBlock('login_content');
     displayNone('login_loader');
     id('current_ID').innerHTML = translate_text_item("guest");
@@ -96,13 +95,13 @@ function DisconnectionSuccess(response_text) {
     displayNone("password_menu");
 }
 
-function DisconnectionFailed(errorcode, response) {
+function DisconnectionFailed(error_code, response) {
     id('current_ID').innerHTML = translate_text_item("guest");
     id('current_auth_level').innerHTML = "";
     displayNone('logout_menu');
     displayNone('logout_menu_divider');
     displayNone("password_menu");
-    console.log("Error " + errorcode + " : " + response);
+    conErr(error_code, response);
 }
 
 function DisconnectLogin(answer) {

--- a/www/js/macrodlg.js
+++ b/www/js/macrodlg.js
@@ -303,7 +303,7 @@ function macroUploadsuccess(response) {
     closeModal('ok');
 }
 
-function macroUploadfailed(errorcode, response) {
+function macroUploadfailed(error_code, response) {
     alertdlg(translate_text_item("Error"), translate_text_item("Save macro list failed!"));
     displayNone('macrodlg_upload_msg');
 }

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -25,10 +25,10 @@ function checkpassword() {
 }
 
 
-function ChangePasswordfailed(errorcode, response_text) {
+function ChangePasswordfailed(error_code, response_text) {
     var response = JSON.parse(response_text);
     if (typeof(response.status) !== 'undefined') id('password_content').innerHTML = translate_text_item(response.status);
-    console.log("Error " + errorcode + " : " + response_text);
+    conErr(error_code, response_text || "");
     displayNone('password_loader');
     displayBlock('change_password_content');
 }

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -134,8 +134,8 @@ function processPreferencesGetSuccess(response) {
     else Preferences_build_list(defaultpreferenceslist);
 }
 
-function processPreferencesGetFailed(errorcode, response) {
-    console.log("Error " + errorcode + " : " + response);
+function processPreferencesGetFailed(error_code, response) {
+    conErr(error_code, response);
     Preferences_build_list(defaultpreferenceslist);
 }
 
@@ -684,7 +684,7 @@ function preferencesUploadsuccess(response) {
     closeModal('ok');
 }
 
-function preferencesUploadfailed(errorcode, response) {
+function preferencesUploadfailed(error_code, response) {
     alertdlg(translate_text_item("Error"), translate_text_item("Save preferences failed!"));
 }
 

--- a/www/js/printercmd.js
+++ b/www/js/printercmd.js
@@ -58,10 +58,10 @@ function SendPrinterCommandSuccess(response) {
 }
 
 function SendPrinterCommandFailed(error_code, response) {
-    if (error_code == 0) {
-        Monitor_output_Update(translate_text_item("Connection error") + "\n");
-    } else {
-         Monitor_output_Update(translate_text_item("Error : ") + error_code + " :" + decode_entitie(response) + "\n");
-    }
-    console.log("printer cmd Error " + error_code + " :" + decode_entitie(response));
+    let errMsg = (error_code == 0)
+        ? translate_text_item("Connection error")
+        : stdErrMsg(error_code, decode_entitie(response), translate_text_item("Error"));
+    Monitor_output_Update(errMsg + "\n");
+
+    conErr(error_code, decode_entitie(response), "printer cmd Error");
 }

--- a/www/js/restartdlg.js
+++ b/www/js/restartdlg.js
@@ -29,9 +29,9 @@ function restart_esp_success(response) {
     //console.log(response);
 }
 
-function restart_esp_failed(errorcode, response) {
+function restart_esp_failed(error_code, response) {
     displayNone('prgrestart');
-    id('restartmsg').innerHTML = translate_text_item("Upload failed : ") + errorcode + " :" + response;
-    console.log("Error " + errorcode + " : " + response);
+    id('restartmsg').innerHTML = stdErrMsg(error_code, response, translate_text_item("Upload failed"));
+    conErr(error_code, response);
     closeModal('Cancel')
 }

--- a/www/js/scanwifidlg.js
+++ b/www/js/scanwifidlg.js
@@ -85,10 +85,10 @@ function getscanWifiSuccess(response) {
 }
 
 function getscanWififailed(error_code, response) {
-    console.log("Error " + error_code + " :" + response);
+    conErr(error_code, response);
     displayNone('AP_scan_loader');
     displayBlock('AP_scan_status');
-    id('AP_scan_status').innerHTML = translate_text_item("Failed:") + error_code + " " + response;
+    id('AP_scan_status').innerHTML = stdErrMsg(error_code, response, translate_text_item("Failed"));
     displayBlock('refresh_scanwifi_btn');
 }
 

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -567,12 +567,13 @@ function setESPsettingsSuccess(response) {
 }
 
 function setESPsettingsfailed(error_code, response) {
-  alertdlg(translate_text_item('Set failed'), 'Error ' + error_code + ' :' + response)
-  console.log('Error ' + error_code + ' :' + response)
-  setBtn(setting_lasti, setting_lastj, 'btn-danger')
-  id('icon_setting_' + setting_lasti + '_' + setting_lastj).className = 'form-control-feedback has-error ico_feedback'
-  id('icon_setting_' + setting_lasti + '_' + setting_lastj).innerHTML = get_icon_svg('remove')
-  setStatus(setting_lasti, setting_lastj, 'has-feedback has-error')
+  const errMsg = stdErrMsg(error_code, response);
+  alertdlg(translate_text_item('Set failed'), errMsg);
+  conErr(errMsg);
+  setBtn(setting_lasti, setting_lastj, 'btn-danger');
+  id('icon_setting_' + setting_lasti + '_' + setting_lastj).className = 'form-control-feedback has-error ico_feedback';
+  id('icon_setting_' + setting_lasti + '_' + setting_lastj).innerHTML = get_icon_svg('remove');
+  setStatus(setting_lasti, setting_lastj, 'has-feedback has-error');
 }
 
 function getESPsettingsSuccess(response) {
@@ -588,11 +589,11 @@ function getESPsettingsSuccess(response) {
 }
 
 function getESPsettingsfailed(error_code, response) {
-  console.log('Error ' + error_code + ' :' + response)
-  displayNone('settings_loader')
-  displayBlock('settings_status')
-  id('settings_status').innerHTML = translate_text_item('Failed:') + error_code + ' ' + response
-  displayBlock('settings_refresh_btn')
+  conErr(error_code, response);
+  displayNone('settings_loader');
+  displayBlock('settings_status');
+  id('settings_status').innerHTML = stdErrMsg(error_code, response, translate_text_item('Failed'));
+  displayBlock('settings_refresh_btn');
 }
 
 function restart_esp() {

--- a/www/js/statusdlg.js
+++ b/www/js/statusdlg.js
@@ -64,12 +64,13 @@ function statussuccess(response) {
     //console.log(response);
 }
 
-function statusfailed(errorcode, response) {
+function statusfailed(error_code, response) {
     displayBlock('refreshstatusbtn');
     displayNone('status_loader');
     displayBlock('status_msg');
-    console.log("Error " + errorcode + " : " + response);
-    id('status_msg').innerHTML = "Error " + errorcode + " : " + response;
+    const errMsg = stdErrMsg(error_code, response);
+    conErr(errMsg);
+    id('status_msg').innerHTML = errMsg;
 }
 
 function refreshstatus() {

--- a/www/js/updatedlg.js
+++ b/www/js/updatedlg.js
@@ -89,7 +89,7 @@ function updatesuccess(response) {
     var interval;
     var x = id("prgfw");
     x.max = 10;
-    interval = setInterval(function() {
+    interval = setInterval(function () {
         i = i + 1;
         var x = id("prgfw");
         x.value = i;
@@ -103,22 +103,22 @@ function updatesuccess(response) {
     //console.log(response);
 }
 
-function updatefailed(errorcode, response) {
+function updatefailed(error_code, response) {
     displayBlock('fw-select_form');
     displayNone('prgfw');
     id("fw_file_name").innerHTML = translate_text_item("No file chosen");
     displayNone('uploadfw-button');
     //id('updatemsg').innerHTML = "";
     id('fw-select').value = "";
-    if (esp_error_code !=0){
-        alertdlg (translate_text_item("Error") + " (" + esp_error_code + ")", esp_error_message);
+    if (esp_error_code != 0) {
+        alertdlg(translate_text_item("Error"), stdErrMsg(`(${esp_error_code})`, esp_error_message));
         id('updatemsg').innerHTML = translate_text_item("Upload failed : ") + esp_error_message;
         esp_error_code = 0;
     } else {
-       alertdlg (translate_text_item("Error"), "Error " + errorcode + " : " + response);
-       id('updatemsg').innerHTML = translate_text_item("Upload failed : ") + errorcode + " :" + response;
+        alertdlg(translate_text_item("Error"), stdErrMsg(error_code, response));
+        id('updatemsg').innerHTML = stdErrMsg(error_code, response, translate_text_item("Upload failed"));
     }
-    console.log("Error " + errorcode + " : " + response);
+    conErr(error_code, response);
     update_ongoing = false;
     SendGetHttp("/updatefw");
 }

--- a/www/js/util.js
+++ b/www/js/util.js
@@ -65,4 +65,17 @@ function getChecked(name) {
   return id(name).checked
 }
 
-const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
+const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+/** Build a 'standard' format error message */
+const stdErrMsg = (error_code, response = "", error_prefix = "Error") => `${error_prefix} ${error_code} : ${response}`;
+/** Use `console.error` to report an error
+ * If the response message is falsey, and the error_prefix is the default, we assume that we've been supplied with a stdErrMsg
+ * Otherwise, we build a stdErrMsg with what was supplied
+ */
+const conErr = (error_code, response, error_prefix = "Error") => {
+  const errMsg = (!response && error_prefix === "Error")
+      ? error_code
+      : stdErrMsg(error_code, response || "", error_prefix);
+  console.error(errMsg);
+}


### PR DESCRIPTION
# Why ?

While working on some other code cleanup this really really got in the way, and I realised I'd prefer it in its own PR, and merged in first. This has been spun up and tested on a real M4. But I'd still recommend trying it out in anger.

# What ?
This standardizes (standardises):

* The terms `errorcode` and `error_code` to be always `error_code`
* Using `console.error` instead of `console.log` for reporting errors, that use `error_code`, to the console. This is done with a utility function `conErr`
* Standardises usage of the `alertdlg` when handling error messages that use an `error_code`
* Standardizes the format of error messages that use `error_code` with a utility function `stdErrMsg`

It does not:
* Change existing usages of `console.error`
* Change any existing function that has `error_code` as a parameter, but which doesn't use it.

A few files had really bad formatting, so they got the VSCode `shift-alt-F` treatment.
