### PR TITLE
Close calibration popup automatically after one second

### DIFF
--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -130,8 +130,8 @@
                   <span class="arrow">&#8600;</span>
                 </div>
                 <div class="buttons-row-col-el">
-                  <button class="calibration-modal-button" onclick="onCalibrationButtonsClick('$CAL','Calibrate'); hideModal('configuration-popup')">Calibrate</button>
-                  <button class="calibration-modal-button" onclick="onCalibrationButtonsClick('$TKSLK','Apply Tension'); hideModal('configuration-popup')">Apply Tension</button>
+                  <button class="calibration-modal-button" onclick="onCalibrationButtonsClick('$CAL','Calibrate'); setTimeout(function() { hideModal('calibration-popup'); }, 1000);">Calibrate</button>
+                  <button class="calibration-modal-button" onclick="onCalibrationButtonsClick('$TKSLK','Apply Tension'); setTimeout(function() { hideModal('calibration-popup'); }, 1000);">Apply Tension</button>
                 </div>
               </div>
               <div class="buttons-row">


### PR DESCRIPTION
Automatically closes the calibration popup after either calibration or take slack is clicked. Just a little quality of life improvement.

This was already how things were supposed to be working, but the name was wrong.