### PR TITLE
Fix calibration communication 

### DIFF
--- a/www/js/calculatesCalibrationStuff.js
+++ b/www/js/calculatesCalibrationStuff.js
@@ -513,7 +513,7 @@ function scaleMeasurementsBasedOnTension(measurements, guess) {
 
 
 function findMaxFitness(measurements) {
-  ({
+  sendCalibrationEvent({
     initialGuess
   }, true);
 

--- a/www/js/calculatesCalibrationStuff.js
+++ b/www/js/calculatesCalibrationStuff.js
@@ -513,7 +513,7 @@ function scaleMeasurementsBasedOnTension(measurements, guess) {
 
 
 function findMaxFitness(measurements) {
-  sendCalibrationEvent({
+  ({
     initialGuess
   }, true);
 
@@ -565,8 +565,8 @@ function findMaxFitness(measurements) {
 
       const tlxStr = bestGuess.tl.x.toFixed(1), tlyStr = bestGuess.tl.y.toFixed(1);
       const trxStr = bestGuess.tr.x.toFixed(1), tryStr = bestGuess.tr.y.toFixed(1);
-      const blxStr = bestGuess.tl.x.toFixed(1), blyStr = bestGuess.tl.y.toFixed(1);
-      const brxStr = bestGuess.tr.x.toFixed(1), bryStr = bestGuess.tr.y.toFixed(1);
+      const blxStr = bestGuess.bl.x.toFixed(1), blyStr = bestGuess.bl.y.toFixed(1);
+      const brxStr = bestGuess.br.x.toFixed(1), bryStr = bestGuess.br.y.toFixed(1);
 
       messagesBox.textContent += `\n${M}_tlX: ${tlxStr}`;
       messagesBox.textContent += `\n${M}_tlY: ${tlyStr}`;
@@ -588,7 +588,7 @@ function findMaxFitness(measurements) {
         sendCommand(`$/${M}_blY=: ${blyStr}`);
         sendCommand(`$/${M}_brX=: ${brxStr}`);
         sendCommand(`$/${M}_brY=: ${bryStr}`);
-
+        
         sendCalibrationEvent({
           good: true,
           final: true,

--- a/www/js/calculatesCalibrationStuff.js
+++ b/www/js/calculatesCalibrationStuff.js
@@ -580,14 +580,14 @@ function findMaxFitness(measurements) {
       messagesBox.scrollTop = messagesBox.scrollHeight;
 
       if (1 / bestGuess.fitness > acceptableCalibrationThreshold) {
-        sendCommand(`$/${M}_tlX=: ${tlxStr}`);
-        sendCommand(`$/${M}_tlY=: ${tlyStr}`);
-        sendCommand(`$/${M}_trX=: ${trxStr}`);
-        sendCommand(`$/${M}_trY=: ${tryStr}`);
-        sendCommand(`$/${M}_blX=: ${blxStr}`);
-        sendCommand(`$/${M}_blY=: ${blyStr}`);
-        sendCommand(`$/${M}_brX=: ${brxStr}`);
-        sendCommand(`$/${M}_brY=: ${bryStr}`);
+        sendCommand(`$/${M}_tlX= ${tlxStr}`);
+        sendCommand(`$/${M}_tlY= ${tlyStr}`);
+        sendCommand(`$/${M}_trX= ${trxStr}`);
+        sendCommand(`$/${M}_trY= ${tryStr}`);
+        sendCommand(`$/${M}_blX= ${blxStr}`);
+        sendCommand(`$/${M}_blY= ${blyStr}`);
+        sendCommand(`$/${M}_brX= ${brxStr}`);
+        sendCommand(`$/${M}_brY= ${bryStr}`);
         
         sendCalibrationEvent({
           good: true,

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -391,9 +391,11 @@ function tabletShowMessage(msg, collecting) {
   }
 
   let errMsg = "";
+
   //These are used for populating the configuration popup
   if (msg.startsWith('$/Maslow_') || msg.startsWith('$/maslow_')) {
     errMsg = maslowMsgHandling(msg.substring(9));
+    return; //We don't want to display these messages
   }
 
   const msgWindow = document.getElementById('messages')


### PR DESCRIPTION
Fixes two typos in the calibration messaging, one being an extra : and one being that the tl and tr values were duplicated for the bl and br.

Fix calibration communication 