### PR TITLE
Fix isdir setting in files

### DIFF
--- a/www/js/files.js
+++ b/www/js/files.js
@@ -414,11 +414,12 @@ const files_list_success = (response_text) => {
 		for (let i = 0; i < response.files.length; i++) {
 			const file = response.files[i];
 			const file_name = file.name;
+			const isdirectory = file.size === "-1";
 			files_file_list.push({
 				name: file_name,
 				sdname: file_name,
-				size: (file.size !== "-1") ? file.size : "",
-				isdir: file.size === "-1",
+				size: !isdirectory ? file.size : "",
+				isdir: isdirectory,
 				datetime: file.datetime,
 				isprintable: files_isgcode(file_name, isdirectory),
 			});


### PR DESCRIPTION
Fixed the isdir member setup in a files object.

This seemed to have a variety of flow on effects. Which it shouldn't, but that requires further work to correct. That's the curse of cleaning up other people's dodgy code (where 'other people' probably includes me).

Specifically also tested retract and extend - no issues with that.