### PR TITLE
Move initUI stuff on its own

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -65,6 +65,7 @@ window.onload = () => {
 	let connectDlg = "";
 	let controlsPanel = "";
 	let navbarLoaded = "";
+	let tabletTab = "";
 
 	let failSafe = 10;
 
@@ -72,24 +73,49 @@ window.onload = () => {
 		// Check for various key HTML panels and load them up
 		if (!connectDlg && id("connectdlg.html")) {
 			connectDlg = "loading";
-			connectdlg();
-			connectDlg = "loaded";
+			try {
+				connectdlg();
+				connectDlg = "loaded";
+			} catch (err) {
+				console.error("Error loading connect dialog:", err);
+				connectDlg = "failed";
+			}
 		}
 
 		if (!controlsPanel && id("controlPanel")) {
 			controlsPanel = "loading";
-			ControlsPanel();
-			controlsPanel = "loaded";
+			try {
+				ControlsPanel();
+				controlsPanel = "loaded";
+			} catch (err) {
+				console.error("Error loading controls panel:", err);
+				controlsPanel = "failed";
+			}
 		}
 
 		if (!navbarLoaded && id("navbar")) {
 			navbarLoaded = "loading";
-			navbar();
-			tabletInit();
-			navbarLoaded = "loaded";
+			try {
+				navbar();
+				navbarLoaded = "loaded";
+			} catch (err) {
+				console.error("Error loading navigation bar:", err);
+				navbarLoaded = "failed";
+			}
 		}
 
-		if ((connectDlg && controlsPanel && navbarLoaded) || failSafe <= 0) {
+		if (!tabletTab && id("tablettab")) {
+			tabletTab = "loading";
+			try {
+				tabletInit();
+				tabletTab = "loaded";
+			} catch (err) {
+				console.error("Error loading tablet tab:", err);
+				tabletTab = "failed";
+			}
+		}
+
+		if ((connectDlg && controlsPanel && navbarLoaded && tabletTab) || failSafe <= 0) {
 			clearInterval(startUpInt);
 			startUpInt = null;
 		}
@@ -98,191 +124,3 @@ window.onload = () => {
 		failSafe--;
 	}, 500);
 }
-
-const total_boot_steps = 5;
-let current_boot_steps = 0;
-
-function display_boot_progress(step) {
-	let val = 1;
-	if (typeof step !== 'undefined') {
-		val = step;
-	}
-	current_boot_steps += val;
-	//console.log(current_boot_steps);
-	//console.log(Math.round((current_boot_steps*100)/total_boot_steps));
-	id('load_prg').value = Math.round((current_boot_steps * 100) / total_boot_steps);
-}
-
-function update_UI_firmware_target() {
-	initpreferences();
-	id('control_x_position_label').innerHTML = 'X';
-	id('control_y_position_label').innerHTML = 'Y';
-	id('control_z_position_label').innerHTML = 'Z';
-	showAxiscontrols();
-
-	const fwName = 'FluidNC';
-	last_grbl_pos = '';
-	displayNone('configtablink');
-	displayNone('auto_check_control');
-	displayNone('progress_btn');
-	displayNone('abort_btn');
-	displayNone('motor_off_control');
-	setHTML("tab_title_configuration", "<span translate>GRBL configuration</span>",);
-	setHTML("tab_printer_configuration", "<span translate>GRBL</span>");
-	const fif = id("files_input_file");
-	if (fif) {
-		fif.accept = " .g, .gco, .gcode, .txt, .ncc, .G, .GCO, .GCODE, .TXT, .NC";
-	}
-	displayInitial('zero_xyz_btn');
-	displayInitial('zero_x_btn');
-	displayInitial('zero_y_btn');
-	if (grblaxis > 2) {
-		//displayInitial('control_z_position_display');
-		setHTML("control_z_position_label", "Zw");
-	} else {
-		hideAxiscontrols();
-		displayNone('preferences_control_z_velocity_group');
-	}
-	build_axis_selection();
-	if (grblaxis > 3) {
-		id('positions_labels2').style.display = 'inline-grid';
-	}
-	if (grblaxis > 3) {
-		id('zero_xyz_btn_txt').innerHTML += 'A';
-		grblzerocmd += ' A0';
-		displayBlock('control_a_position_display');
-		displayBlock('preferences_control_a_velocity_group');
-	}
-	if (grblaxis > 4) {
-		id('zero_xyz_btn_txt').innerHTML += 'B';
-		grblzerocmd += ' B0';
-		displayBlock('control_b_position_display');
-		displayBlock('preferences_control_b_velocity_group');
-	}
-	if (grblaxis > 5) {
-		id('zero_xyz_btn_txt').innerHTML += 'C';
-		grblzerocmd += ' C0';
-		displayBlock('control_c_position_display');
-		displayBlock('preferences_control_c_velocity_group');
-	} else {
-		displayNone('control_c_position_display');
-	}
-	displayFlex('grblPanel');
-	grblpanel();
-	// id('FW_github').href = 'https://github.com/bdring/FluidNC';
-	displayBlock('settings_filters'); // TODO: Or should this be 'preferences_filters'?
-	id('control_x_position_label').innerHTML = 'Xw';
-	id('control_y_position_label').innerHTML = 'Yw';
-
-	EP_HOSTNAME = 'Hostname';
-	EP_STA_SSID = 'Sta/SSID';
-	EP_STA_PASSWORD = 'Sta/Password';
-	EP_STA_IP_MODE = 'Sta/IPMode';
-	EP_STA_IP_VALUE = 'Sta/IP';
-	EP_STA_GW_VALUE = 'Sta/Gateway';
-	EP_STA_MK_VALUE = 'Sta/Netmask';
-	EP_WIFI_MODE = 'WiFi/Mode';
-	EP_AP_SSID = 'AP/SSID';
-	EP_AP_PASSWORD = 'AP/Password';
-	EP_AP_IP_VALUE = 'AP/IP';
-	SETTINGS_AP_MODE = 2;
-	SETTINGS_STA_MODE = 1;
-
-	setHTML("fwName", fwName);
-	//SD image or not
-	setHTML(
-		"showSDused",
-		direct_sd
-			? "<svg width='1.3em' height='1.2em' viewBox='0 0 1300 1200'><g transform='translate(50,1200) scale(1, -1)'><path  fill='#777777' d='M200 1100h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212v500q0 124 88 212t212 88zM100 900v-700h900v700h-900zM500 700h-200v-100h200v-300h-300v100h200v100h-200v300h300v-100zM900 700v-300l-100 -100h-200v500h200z M700 700v-300h100v300h-100z' /></g></svg>"
-			: "",
-	);
-
-	return fwName
-}
-
-function Set_page_title(page_title) {
-	if (typeof page_title !== 'undefined') esp_hostname = page_title
-	document.title = esp_hostname
-}
-
-function initUI() {
-	console.log('Init UI');
-	if (ESP3D_authentication) {
-		connectdlg(false);
-	}
-	AddCmd(display_boot_progress);
-	//initial check
-	if (typeof target_firmware === 'undefined' || typeof web_ui_version === 'undefined' || typeof direct_sd === 'undefined')
-		alert('Missing init data!');
-	//check FW
-	update_UI_firmware_target();
-	//set title using hostname
-	Set_page_title();
-	//update UI version
-	setHTML("UI_VERSION", web_ui_version);
-	//update FW version
-	setHTML("FW_VERSION", fw_version);
-	// Get the element with id="defaultOpen" and click on it
-	id('tablettablink').click()
-
-	if (typeof id('grblcontroltablink') !== 'undefined') {
-		id('grblcontroltablink').click()
-	}
-
-	//removeIf(production)
-	console.log(JSON.stringify(translated_list));
-	//endRemoveIf(production)
-	initUI_2();
-
-	setTimeout(tryAutoReport, 500); //Not sure why this needs a delay but it seems like a hack
-}
-
-function initUI_2() {
-	AddCmd(display_boot_progress);
-	//get all settings from ESP3D
-	console.log('Get settings');
-	//query settings but do not update list in case wizard is showed
-	refreshSettings(true);
-	initUI_3();
-}
-
-function initUI_3() {
-	AddCmd(display_boot_progress);
-
-	console.log('Get preferences');
-	getpreferenceslist();
-
-	//init panels
-	console.log('Get macros');
-	init_controls_panel();
-	init_grbl_panel();
-	initUI_4();
-}
-
-function initUI_4() {
-	AddCmd(display_boot_progress);
-	init_command_panel();
-	init_files_panel(false);
-	//check if we need setup
-	if (target_firmware === "???") {
-		console.log("Launch Setup");
-		AddCmd(display_boot_progress);
-		closeModal("Connection successful");
-		setupdlg();
-	} else {
-		//wizard is done UI can be updated
-		setup_is_done = true;
-		do_not_build_settings = false;
-		AddCmd(display_boot_progress);
-		build_HTML_setting_list(current_setting_filter);
-		AddCmd(closeModal);
-		AddCmd(show_main_UI);
-	}
-}
-
-function show_main_UI() {
-	displayUndoNone('main_ui');
-}
-
-// var socket_response = ''
-// var socket_is_settings = false

--- a/www/js/controls.js
+++ b/www/js/controls.js
@@ -25,24 +25,6 @@ const ControlsPanel = () => {
 	id("motor_off_control").addEventListener("click", (event) => control_motorsOff());
 };
 
-function hideAxiscontrols() {
-	displayNone("JogBar");
-	displayNone("HomeZ");
-	displayBlock("CornerZ");
-	displayNone("control_z_position_display");
-	displayNone("control_zm_position_row");
-	displayNone("z_feedrate_display");
-}
-
-function showAxiscontrols() {
-	displayNone("CornerZ");
-	displayBlock("JogBar");
-	displayBlock("HomeZ");
-	displayBlock("control_z_position_display");
-	displayTable("control_zm_position_row");
-	displayInline("z_feedrate_display");
-}
-
 function loadmacrolist() {
 	control_macrolist = [];
 	var url = "/macrocfg.json";

--- a/www/js/grbl.js
+++ b/www/js/grbl.js
@@ -47,7 +47,7 @@ const build_axis_selection = () => {
   ];
 
   const html = ["<select class='form-control wauto' id='control_select_axis' onchange='control_changeaxis()' >"];
-  for (var i = 3; i <= grblaxis; i++) {
+  for (let i = 3; i <= grblaxis; i++) {
     html.push(axisOpts[i - 3]);
   }
   html.push("</select>");

--- a/www/js/initUI.js
+++ b/www/js/initUI.js
@@ -1,0 +1,190 @@
+/** Set the page's title */
+const Set_page_title = (page_title = "") => {
+	if (page_title) {
+        esp_hostname = page_title;
+    }
+	document.title = esp_hostname;
+}
+
+const hideAxiscontrols = () => {
+	displayNone(["JogBar", "HomeZ", "control_z_position_display", "control_zm_position_row", "z_velocity_display"]);
+	displayBlock("CornerZ");
+}
+
+const showAxiscontrols = () => {
+	displayNone("CornerZ");
+	displayBlock(["JogBar", "HomeZ", "control_z_position_display"]);
+	displayTable("control_zm_position_row");
+	displayInline("z_velocity_display");
+}
+
+const update_UI_firmware_target = () => {
+	initpreferences();
+	setHTML("control_x_position_label", "X");
+	setHTML("control_y_position_label", "Y");
+	setHTML("control_z_position_label", "Z");
+	showAxiscontrols();
+
+	displayNone("configtablink");
+	displayNone("auto_check_control");
+	displayNone("progress_btn");
+	displayNone("abort_btn");
+	displayNone("motor_off_control");
+	setHTML("tab_title_configuration", "<span translate>GRBL configuration</span>",);
+	setHTML("tab_printer_configuration", "<span translate>GRBL</span>");
+
+	const fif = id("files_input_file");
+	if (fif) {
+		fif.accept = " .g, .gco, .gcode, .txt, .ncc, .G, .GCO, .GCODE, .TXT, .NC";
+	}
+	displayInitial("zero_xyz_btn");
+	displayInitial("zero_x_btn");
+	displayInitial("zero_y_btn");
+	if (grblaxis > 2) {
+		//displayInitial('control_z_position_display');
+		setHTML("control_z_position_label", "Zw");
+	} else {
+		hideAxiscontrols();
+		displayNone("z_feedrate_group");
+	}
+	if (grblaxis > 3) {
+		build_axis_selection();
+		grblzerocmd += " A0";
+        id("zero_xyz_btn_txt").innerHTML += "A";
+		displayBlock("a_feedrate_group");
+		displayBlock("control_a_position_display");
+		id("positions_labels2").style.display = "inline-grid";
+	}
+	if (grblaxis > 4) {
+		grblzerocmd += " B0";
+		id("zero_xyz_btn_txt").innerHTML += "B";
+        displayBlock("b_feedrate_group");
+        displayBlock("control_b_position_display");
+	}
+	if (grblaxis > 5) {
+		grblzerocmd += " C0";
+		id("zero_xyz_btn_txt").innerHTML += "C";
+		displayBlock("c_feedrate_group");
+		displayBlock("control_c_position_display");
+	} else {
+		displayNone("control_c_position_display");
+	}
+	displayFlex("grblPanel");
+	grblpanel();
+	// id('FW_github').href = 'https://github.com/bdring/FluidNC';
+	displayBlock("settings_filters");
+	setHTML("control_x_position_label", "Xw");
+	setHTML("control_y_position_label", "Yw");
+
+    EP_HOSTNAME = 'Hostname';
+	EP_STA_SSID = 'Sta/SSID';
+	EP_STA_PASSWORD = 'Sta/Password';
+	EP_STA_IP_MODE = 'Sta/IPMode';
+	EP_STA_IP_VALUE = 'Sta/IP';
+	EP_STA_GW_VALUE = 'Sta/Gateway';
+	EP_STA_MK_VALUE = 'Sta/Netmask';
+	EP_WIFI_MODE = 'WiFi/Mode';
+	EP_AP_SSID = 'AP/SSID';
+	EP_AP_PASSWORD = 'AP/Password';
+	EP_AP_IP_VALUE = 'AP/IP';
+	// Swap AP Mode and STA Mode
+	SETTINGS_AP_MODE = 2;
+	SETTINGS_STA_MODE = 1;
+
+	const fwName = "FluidNC";
+	setHTML("fwName", fwName);
+	//SD image or not
+	setHTML(
+		"showSDused",
+		direct_sd
+			? "<svg width='1.3em' height='1.2em' viewBox='0 0 1300 1200'><g transform='translate(50,1200) scale(1, -1)'><path  fill='#777777' d='M200 1100h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212v500q0 124 88 212t212 88zM100 900v-700h900v700h-900zM500 700h-200v-100h200v-300h-300v100h200v100h-200v300h300v-100zM900 700v-300l-100 -100h-200v500h200z M700 700v-300h100v300h-100z' /></g></svg>"
+			: "",
+	);
+
+	return fwName;
+}
+
+const total_boot_steps = 5;
+let current_boot_steps = 0;
+
+const display_boot_progress = () => {
+	current_boot_steps++;
+	id("load_prg").value = Math.round((current_boot_steps * 100) / total_boot_steps);
+}
+
+/** InitUI step1 - try to connect to the ESP32 */
+const initUI = () => {
+	console.log("Init UI - Step 1");
+
+	// Start up connect dialog, don't try and get the FW data
+	if (ESP3D_authentication) {
+		connectdlg(false);
+	}
+
+	AddCmd(display_boot_progress);
+	//check FW
+	update_UI_firmware_target();
+	//set title using hostname
+	Set_page_title();
+	//update UI version
+	setHTML("UI_VERSION", web_ui_version);
+	//update FW version
+	setHTML("FW_VERSION", fw_version);
+	// Get the element with id="defaultOpen" and click on it
+	id("tablettablink").click();
+
+	if (typeof id("grblcontroltablink") !== "undefined") {
+		id("grblcontroltablink").click();
+	}
+
+	initUI_2();
+
+	setTimeout(tryAutoReport, 500); //Not sure why this needs a delay but it seems like a hack
+}
+
+/** InitUI step2 - get settings from ESP3D and start processing them */
+function initUI_2() {
+	console.log("Init UI - Step 2 - Get Settings");
+	AddCmd(display_boot_progress);
+	//query settings but do not update list in case wizard is showed
+	refreshSettings(true);
+	initUI_3();
+}
+
+/** InitUI step3 - Initialise the control and GRBL panels, get the preferences */
+function initUI_3() {
+	console.log("Init UI - Step 3 - Initialise the control and GRBL panels, get the preferences");
+	AddCmd(display_boot_progress);
+	//init panels
+	init_controls_panel();
+	init_grbl_panel();
+	getpreferenceslist();
+	initUI_4();
+}
+
+/** InitUI step4 - Initialise the command and files panels, determine if the setup wizard needs to be run */
+function initUI_4() {
+	console.log("Init UI - Step 4 - Initialise the command and files panels, determine if the setup wizard needs to be run");
+	AddCmd(display_boot_progress);
+	init_command_panel();
+	init_files_panel(false);
+	//check if we need setup
+	if (target_firmware === "???") {
+		console.log("Launch Setup");
+		AddCmd(display_boot_progress);
+		closeModal("Connection successful");
+		setupdlg();
+	} else {
+		//wizard is done UI can be updated
+	    setup_is_done = true;
+		do_not_build_settings = false;
+		AddCmd(display_boot_progress);
+		build_HTML_setting_list(current_setting_filter);
+		AddCmd(closeModal);
+		AddCmd(show_main_UI);
+	}
+}
+
+function show_main_UI() {
+	displayUndoNone("main_ui");
+}

--- a/www/js/socket.js
+++ b/www/js/socket.js
@@ -148,21 +148,15 @@ const startSocket = () => {
 				msg += String.fromCharCode(bytes[i]);
 				if (bytes[i] === 10) {
 					wsmsg += msg.replace("\r\n", "\n");
-					const thismsg = wsmsg;
+					const thismsg = wsmsg.trim();
 					wsmsg = "";
 					msg = "";
 					Monitor_output_Update(thismsg);
 					process_socket_response(thismsg);
-					if (
-						!(
-							thismsg.startsWith("<") ||
-							thismsg.startsWith("ok T:") ||
-							thismsg.startsWith("X:") ||
-							thismsg.startsWith("FR:") ||
-							thismsg.startsWith("echo:E0 Flow")
-						)
-					)
+					const noNeedToShowMsg = ["<", "ok T:", "X:", "FR:", "echo:E0 Flow"].some((msgStart) => thismsg.startsWith(msgStart));
+					if (!noNeedToShowMsg && thismsg !== "ok") {
 						console.log(thismsg);
+					}
 				}
 			}
 			wsmsg += msg;


### PR DESCRIPTION
This moves the initUI functionality out into its own JS file, making app.js much more focussed.

It adds some try/catch handling around what app.js does, making the whole app a little more robust - although this won't catch everything.

It also makes a minor change to the logging done by socket.js, in particular to get rid of the annoying `ok` messages.

nice, simple PR

I've tested this on one of my machines.