### PR TITLE
Better handling of connect, and any errors (slightly)

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -74,7 +74,7 @@ window.onload = () => {
 		if (!connectDlg && id("connectdlg.html")) {
 			connectDlg = "loading";
 			try {
-				connectdlg();
+				connectdlg(true);
 				connectDlg = "loaded";
 			} catch (err) {
 				console.error("Error loading connect dialog:", err);

--- a/www/js/connectdlg.js
+++ b/www/js/connectdlg.js
@@ -1,13 +1,11 @@
 // import conErr, displayBlock, displayInline, displayNone, id, closeModal, setactiveModal, showModal, SendGetHttp, logindlg, EventListenerSetup, startSocket,
 
 /** Connect Dialog */
-const connectdlg = (getFw = true) => {
+const connectdlg = (getFw = false) => {
 	const modal = setactiveModal("connectdlg.html");
 	if (modal == null) {
 		return;
 	}
-
-	id("connectbtn").addEventListener("click", (event) => retryconnect());
 
 	showModal();
 
@@ -102,12 +100,15 @@ const connectfailed = (error_code, response) => {
 	displayBlock("connectbtn");
 	displayBlock("failed_connect_msg");
 	displayNone("connecting_msg");
-	conErr(error_code, response, "Fw identification error");
+
+	id("connectbtn").addEventListener("click", retryconnect);
+
+	conErr(error_code, response, "FW identification error");
 };
 
 const connectsuccess = (response) => {
 	if (getFWdata(response)) {
-		console.log(`Fw identification:${response}`);
+		console.log(`FW identification:${response}`);
 		if (ESP3D_authentication) {
 			closeModal("Connection successful");
 			displayInline("menu_authentication");
@@ -126,6 +127,9 @@ const retryconnect = () => {
 	displayNone("connectbtn");
 	displayNone("failed_connect_msg");
 	displayBlock("connecting_msg");
+
+	id("connectbtn").removeEventListener("click", retryconnect);
+
 	const url = `/command?plain=${encodeURIComponent("[ESP800]")}`;
 	SendGetHttp(url, connectsuccess, connectfailed);
 };

--- a/www/sub/connectdlg.html
+++ b/www/sub/connectdlg.html
@@ -12,12 +12,12 @@
                 <span translate>Please wait...</span>
                 <progress id='load_prg' max='100'></progress>
             </span>
-            <span class="hide_it" id="failed_connect_msg">
+            <span id="failed_connect_msg" class="hide_it">
                 <span translate>Connection failed! is your FW correct?</span>
             </span>
         </div>
         <div class="modal-footer">
-            <button class="btn btn-primary center" id="connectbtn" translate>Retry</button>
+            <button id="connectbtn" class="btn btn-primary center" translate>Retry</button>
         </div>
     </div>
     <!-- /Connect content -->


### PR DESCRIPTION
Slight tweaks to the way that the connectdlg is started up, and therefore how it calls for the FW data.

Not really a problem for the maslow-main branch, but seemed to be impacting my `bun` branch.

Key change is that the default for `getFw` for `connectdlg` has been changed from `true` to `false`, meaning that if there's any odd restarts of the connectdlg, they won't have any undesirable side effects.