### PR TITLE
Standardise the definition of various http 'commands'

### DIFF
--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -47,7 +47,8 @@ const buildTable = (content) => `<table>${content}</table>`;
 const buildTr = (content) => `<tr>${content}</tr>`;
 
 function SPIFFSselect_dir(directoryname) {
-	SPIFFS_currentpath = directoryname + directoryname.endsWith("/") ? "" : "/";
+	const needTraillingSlash = directoryname.endsWith("/") ? "" : "/";
+	SPIFFS_currentpath = directoryname + needTraillingSlash;
 	SPIFFSSendCommand("list", "all");
 }
 
@@ -130,10 +131,8 @@ function processSPIFFSRename(new_file_name) {
 	if (!new_file_name) {
 		return;
 	}
-	let url = `/files?action=rename&path=${encodeURIComponent(SPIFFS_currentpath)}`;
-	url += `&filename=${encodeURIComponent(old_file_name)}`;
-	url += `&newname=${encodeURIComponent(new_file_name)}`;
-	SendGetHttp(url, SPIFFSsuccess, SPIFFSfailed);
+	const cmd = buildHttpFilesCmd({ action: "rename", path: SPIFFS_currentpath, filename: old_file_name, newname: new_file_name });
+	SendGetHttp(cmd, SPIFFSsuccess, SPIFFSfailed);
 }
 
 const testResponse = [
@@ -153,10 +152,10 @@ function SPIFFSSendCommand(action, filename) {
 	SPIFFSsuccess(testResponse.join(""));
 	return;
 	//endRemoveIf(production)
-	let url = `/files?action=${action}&filename=${encodeURI(filename)}&path=${encodeURI(SPIFFS_currentpath)}`;
 	id("SPIFFS_loader").style.visibility = "visible";
-	console.log(url);
-	SendGetHttp(url, SPIFFSsuccess, SPIFFSfailed);
+	const cmd = buildHttpFilesCmd({ action: action, path: SPIFFS_currentpath, filename: filename });
+	console.log(cmd);
+	SendGetHttp(cmd, SPIFFSsuccess, SPIFFSfailed);
 }
 
 function SPIFFSsuccess(response) {

--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -311,8 +311,8 @@ function SPIFFS_UploadFile() {
 		return;
 	}
 	const files = id("SPIFFS-select").files;
+
 	const formData = new FormData();
-	const url = "/files";
 	formData.append("path", SPIFFS_currentpath);
 	for (let i = 0; i < files.length; i++) {
 		const file = files[i];
@@ -321,6 +321,7 @@ function SPIFFS_UploadFile() {
 		formData.append(arg, file.size);
 		formData.append("myfile[]", file, `${SPIFFS_currentpath}${file.name}`);
 	}
+
 	displayNone("SPIFFS-select_form");
 	displayNone("SPIFFS_uploadbtn");
 	SPIFFS_upload_ongoing = true;
@@ -328,7 +329,7 @@ function SPIFFS_UploadFile() {
 	displayBlock("SPIFFS_prg");
 	SPIFFS_currentfile = (files.length === 1) ? files[0].name : "";
 	setHTML("uploadSPIFFSmsg", `${translate_text_item("Uploading")} ${SPIFFS_currentfile}`);
-	SendFileHttp(url, formData, SPIFFSUploadProgressDisplay, SPIFFSUploadsuccess, SPIFFSUploadfailed);
+	SendFileHttp(httpCmd.files, formData, SPIFFSUploadProgressDisplay, SPIFFSUploadsuccess, SPIFFSUploadfailed);
 }
 
 function SPIFFSUploadsuccess(response) {

--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -193,7 +193,7 @@ const buildSPIFFSTotalBar = (jsonresponse) => {
 };
 
 const upDirAndRelist = (previouspath) => {
-	SPIFFS_currentpath(previouspath);
+	SPIFFS_currentpath = previouspath;
 	SPIFFSSendCommand("list", "all");
 };
 

--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -1,7 +1,12 @@
 //import - get_icon_svg, conErr, stdErrMsg, displayBlock, displayNone, id, setValue, setHTML, closeModal, setactiveModal, showModal, alertdlg, confirmdlg, inputdlg, SendFileHttp, SendGetHttp, translate_text_item
 
+let SPIFFS_currentpath = "/";
 let SPIFFS_currentfile = "";
 let SPIFFS_upload_ongoing = false;
+
+const SPIFSSDialogClose = () => closeSPIFFSDialog("cancel");
+const SPIFFSSelectClick = () => document.getElementById("SPIFFS_select").click();
+const SPIFFSSelectFilesClick = () => document.getElementById("SPIFFS_select_files").click();
 
 /** SPIFFS dialog */
 const SPIFFSdlg = (root) => {
@@ -10,19 +15,19 @@ const SPIFFSdlg = (root) => {
 		return;
 	}
 
-	id("SPIFFS_span_close").addEventListener("click", (event) => closeSPIFFSDialog("cancel"));
-	id("SPIFFS-select").addEventListener("change", (event) => checkSPIFFSfiles());
-	id("SPIFFS_select_files").addEventListener("click", (event) => document.getElementById("SPIFFS-select").click());
-	id("SPIFFS_file_name").addEventListener("mouseup", (event) => document.getElementById("SPIFFS_select_files").click());
-	id("SPIFFS_uploadbtn").addEventListener("click", (event) => SPIFFS_UploadFile());
-	id("SPIFFS_create_dir_btn").addEventListener("click", (event) => SPIFFS_Createdir());
-	id("SPIFFS_btn_close").addEventListener("click", (event) => closeSPIFFSDialog("cancel"));
-	id("refreshSPIFFSbtn").addEventListener("click", (event) => refreshSPIFFS());
+	id("SPIFFS_span_close").addEventListener("click", SPIFSSDialogClose);
+	id("SPIFFS_select").addEventListener("change", checkSPIFFSfiles);
+	id("SPIFFS_select_files").addEventListener("click", SPIFFSSelectClick);
+	id("SPIFFS_file_name").addEventListener("mouseup", SPIFFSSelectFilesClick);
+	id("SPIFFS_uploadbtn").addEventListener("click", SPIFFS_UploadFile);
+	id("SPIFFS_create_dir_btn").addEventListener("click", SPIFFS_Createdir);
+	id("SPIFFS_btn_close").addEventListener("click", SPIFSSDialogClose);
+	id("refreshSPIFFSbtn").addEventListener("click", refreshSPIFFS);
 
 	if (typeof root !== "undefined") {
 		SPIFFS_currentpath = root;
 	}
-	setValue("SPIFFS-select", "");
+	setValue("SPIFFS_select", "");
 	setHTML("SPIFFS_file_name", translate_text_item("No file chosen"));
 	displayNone("SPIFFS_uploadbtn");
 	displayNone("SPIFFS_prg");
@@ -34,10 +39,7 @@ const SPIFFSdlg = (root) => {
 
 function closeSPIFFSDialog(msg) {
 	if (SPIFFS_upload_ongoing) {
-		alertdlg(
-			translate_text_item("Busy..."),
-			translate_text_item("Upload is ongoing, please wait and retry."),
-		);
+		alertdlg(translate_text_item("Busy..."), translate_text_item("Upload is ongoing, please wait and retry."));
 		return;
 	}
 	closeModal(msg);
@@ -74,7 +76,10 @@ const SPIFFSnavbar = () => {
 
 	setHTML("SPIFFS_path", buildTable(buildTr(content)));
 	actions.forEach((action) => {
-		id(action.id).addEventListener("click", (event) => action.method(action.path));
+		const elem = id(action.id);
+		if (elem) {
+			elem.addEventListener("click", (event) => action.method(action.path));
+		}
 	});
 };
 
@@ -264,7 +269,7 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
 }
 
 function refreshSPIFFS() {
-	setValue("SPIFFS-select", "");
+	setValue("SPIFFS_select", "");
 	setHTML("uploadSPIFFSmsg", "");
 	setHTML("SPIFFS_file_name", translate_text_item("No file chosen"));
 	displayNone("SPIFFS_uploadbtn");
@@ -278,7 +283,7 @@ function refreshSPIFFS() {
 }
 
 function checkSPIFFSfiles() {
-	const files = id("SPIFFS-select").files;
+	const files = id("SPIFFS_select").files;
 	displayNone("uploadSPIFFSmsg");
 	// No need to display the upload button because we will click it automatically
 	// displayFiles('SPIFFS_uploadbtn');
@@ -310,7 +315,7 @@ function SPIFFS_UploadFile() {
 		alertdlg(translate_text_item("Busy..."), translate_text_item("Communications are currently locked, please wait and retry."),);
 		return;
 	}
-	const files = id("SPIFFS-select").files;
+	const files = id("SPIFFS_select").files;
 	const formData = new FormData();
 	const url = "/files";
 	formData.append("path", SPIFFS_currentpath);
@@ -332,7 +337,7 @@ function SPIFFS_UploadFile() {
 }
 
 function SPIFFSUploadsuccess(response) {
-	setValue("SPIFFS-select", "");
+	setValue("SPIFFS_select", "");
 	setHTML("SPIFFS_file_name", translate_text_item("No file chosen"));
 	displayBlock("SPIFFS-select_form");
 	displayNone("SPIFFS_prg");

--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -326,7 +326,7 @@ function SPIFFS_UploadFile() {
 		formData.append(arg, file.size);
 		formData.append("myfile[]", file, `${SPIFFS_currentpath}${file.name}`);
 	}
-	displayNone("SPIFFS-select_form");
+	displayNone("SPIFFS_select_form");
 	displayNone("SPIFFS_uploadbtn");
 	SPIFFS_upload_ongoing = true;
 	displayBlock("uploadSPIFFSmsg");
@@ -339,7 +339,7 @@ function SPIFFS_UploadFile() {
 function SPIFFSUploadsuccess(response) {
 	setValue("SPIFFS_select", "");
 	setHTML("SPIFFS_file_name", translate_text_item("No file chosen"));
-	displayBlock("SPIFFS-select_form");
+	displayBlock("SPIFFS_select_form");
 	displayNone("SPIFFS_prg");
 	displayNone("SPIFFS_uploadbtn");
 	setHTML("uploadSPIFFSmsg", "");
@@ -350,7 +350,7 @@ function SPIFFSUploadsuccess(response) {
 }
 
 function SPIFFSUploadfailed(error_code, response) {
-	displayBlock("SPIFFS-select_form");
+	displayBlock("SPIFFS_select_form");
 	displayNone("SPIFFS_prg");
 	displayBlock("SPIFFS_uploadbtn");
 	setHTML("uploadSPIFFSmsg", "");

--- a/www/js/UIdisableddlg.js
+++ b/www/js/UIdisableddlg.js
@@ -1,5 +1,7 @@
 // import translate_text_item, id, setHTML, setactiveModal, showModal, saveSerialMessages
 
+const UIdisabledDlgReconnect = () => window.location.reload();
+
 //UIdisabled dialog
 const UIdisableddlg = (lostcon) => {
 	const modal = setactiveModal("UIdisableddlg.html");
@@ -7,8 +9,8 @@ const UIdisableddlg = (lostcon) => {
 		return;
 	}
 
-	id("UIdisabled_reconnect").addEventListener("click", (event) => window.location.reload());
-	id("UIdisabled_save_serial_msg").addEventListener("click", (event) => saveSerialMessages());
+	id("UIdisabled_reconnect").addEventListener("click", UIdisabledDlgReconnect);
+	id("UIdisabled_save_serial_msg").addEventListener("click", saveSerialMessages);
 
 	if (lostcon) {
 		setHTML("disconnection_msg", translate_text_item("Connection lost for more than 20s"));

--- a/www/js/alertdlg.js
+++ b/www/js/alertdlg.js
@@ -1,5 +1,8 @@
 // This uses: closeModal, setactiveModal, showModal, id
 
+const alertDlgCancel = () => closeModal("cancel");
+const alertDlgClose = () => closeModal("Ok");
+
 /** alert dialog */
 const alertdlg = (titledlg, textdlg, closefunc) => {
 	const modal = setactiveModal("alertdlg.html", closefunc);
@@ -7,8 +10,8 @@ const alertdlg = (titledlg, textdlg, closefunc) => {
 		return;
 	}
 
-	id("cancelAlertDlg").addEventListener("click", (event) => closeModal("cancel"));
-	id("closeAlertDlg").addEventListener("click", (event) => closeModal("Ok"));
+	id("cancelAlertDlg").addEventListener("click", alertDlgCancel);
+	id("closeAlertDlg").addEventListener("click", alertDlgClose);
 
 	const title = modal.element.getElementsByClassName("modal-title")[0];
 	const body = modal.element.getElementsByClassName("modal-text")[0];

--- a/www/js/camera.js
+++ b/www/js/camera.js
@@ -2,12 +2,12 @@
 
 /** Set up the event handlers for the camera tab */
 const cameratab = () => {
-	id("camera_webaddress").addEventListener("keyup", (event) => camera_OnKeyUp(event));
+	id("camera_webaddress").addEventListener("keyup", camera_OnKeyUp);
 
-	id("cameratab_loadframe").addEventListener("click", (event) => camera_loadframe());
-	id("cameratab_getaddress").addEventListener("click", (event) => camera_GetAddress());
-	id("cameratab_saveaddress").addEventListener("click", (event) => camera_saveaddress());
-	id("camera_detach_button").addEventListener("click", (event) => camera_detachcam());
+	id("cameratab_loadframe").addEventListener("click", camera_loadframe);
+	id("cameratab_getaddress").addEventListener("click", camera_GetAddress);
+	id("cameratab_saveaddress").addEventListener("click", camera_saveaddress);
+	id("camera_detach_button").addEventListener("click", camera_detachcam);
 };
 
 function cameraformataddress() {
@@ -51,9 +51,9 @@ function camera_OnKeyUp(event) {
 }
 
 function camera_saveaddress() {
-    cameraformataddress();
-    preferenceslist[0].camera_address = HTMLEncode(id('camera_webaddress').value);
-    SavePreferences(true);
+	cameraformataddress();
+	preferenceslist[0].camera_address = HTMLEncode(id('camera_webaddress').value);
+	SavePreferences(true);
 }
 
 function camera_detachcam() {

--- a/www/js/commands.js
+++ b/www/js/commands.js
@@ -6,11 +6,11 @@ let Monitor_output = [];
 
 /** Set up the event handlers for the commands panel */
 const init_command_panel = () => {
-	id("clear_monitor_btn").addEventListener("click", (event) => Monitor_output_Clear());
-	id("custom_cmd_txt").addEventListener("keyup", (event) => CustomCommand_OnKeyUp(event));
-	id("commandspanel_send").addEventListener("click", (event) => SendCustomCommand());
-	id("monitor_enable_autoscroll").addEventListener("click", (event) => Monitor_check_autoscroll());
-	id("monitor_enable_verbose_mode").addEventListener("click", (event) => Monitor_check_verbose_mode());
+	id("clear_monitor_btn").addEventListener("click", Monitor_output_Clear);
+	id("custom_cmd_txt").addEventListener("keyup", CustomCommand_OnKeyUp);
+	id("commandspanel_send").addEventListener("click", SendCustomCommand);
+	id("monitor_enable_autoscroll").addEventListener("click", Monitor_check_autoscroll);
+	id("monitor_enable_verbose_mode").addEventListener("click", Monitor_check_verbose_mode);
 };
 
 function Monitor_output_autoscrollcmd() {

--- a/www/js/commands.js
+++ b/www/js/commands.js
@@ -103,19 +103,20 @@ const Monitor_output_Update = (message) => {
 };
 
 function SendCustomCommand() {
-	let cmd = id("custom_cmd_txt").value;
-	const url = "/command?commandText=";
-	cmd = cmd.trim();
-	if (cmd.trim().length === 0) return;
-	CustomCommand_history.push(cmd);
+	let custCmd = id("custom_cmd_txt").value.trim();
+	if (custCmd.trim().length === 0) {
+		return;
+	}
+
+	CustomCommand_history.push(custCmd);
 	CustomCommand_history.slice(-40);
 	CustomCommand_history_index = CustomCommand_history.length;
+
 	id("custom_cmd_txt").value = "";
-	Monitor_output_Update(`${cmd}\n`);
-	cmd = encodeURI(cmd);
-	//because # is not encoded
-	cmd = cmd.replace("#", "%23");
-	SendGetHttp(url + cmd, SendCustomCommandSuccess, SendCustomCommandFailed);
+	Monitor_output_Update(`${custCmd}\n`);
+
+	const cmd = buildHttpCommandCmd(custCmd);
+	SendGetHttp(cmd, SendCustomCommandSuccess, SendCustomCommandFailed);
 }
 
 function CustomCommand_OnKeyUp(event) {

--- a/www/js/commands.js
+++ b/www/js/commands.js
@@ -115,7 +115,7 @@ function SendCustomCommand() {
 	id("custom_cmd_txt").value = "";
 	Monitor_output_Update(`${custCmd}\n`);
 
-	const cmd = buildHttpCommandCmd(custCmd);
+	const cmd = buildHttpCommandCmd(httpCmdType.commandText, custCmd);
 	SendGetHttp(cmd, SendCustomCommandSuccess, SendCustomCommandFailed);
 }
 

--- a/www/js/commands.js
+++ b/www/js/commands.js
@@ -103,8 +103,8 @@ const Monitor_output_Update = (message) => {
 };
 
 function SendCustomCommand() {
-	let custCmd = id("custom_cmd_txt").value.trim();
-	if (custCmd.trim().length === 0) {
+	const custCmd = getValue("custom_cmd_txt")?.trim() || "";
+	if (!custCmd) {
 		return;
 	}
 
@@ -112,7 +112,7 @@ function SendCustomCommand() {
 	CustomCommand_history.slice(-40);
 	CustomCommand_history_index = CustomCommand_history.length;
 
-	id("custom_cmd_txt").value = "";
+	setValue("custom_cmd_txt", "");
 	Monitor_output_Update(`${custCmd}\n`);
 
 	const cmd = buildHttpCommandCmd(httpCmdType.commandText, custCmd);

--- a/www/js/config.js
+++ b/www/js/config.js
@@ -5,7 +5,7 @@ var config_error_msg = "";
 var config_lastindex_is_override = false;
 var commandtxt = "$$";
 var is_override_config = false;
-var config_file_name = "/sd/config";
+// var config_file_name = "/sd/config";
 
 
 function refreshconfig(is_override) {
@@ -43,17 +43,17 @@ function getprinterconfig(is_override = false) {
     if (is_override) {
         config_override_List = [];
     }
-    const cmd = buildHttpPlainCmd(plainCmd);
+    const cmd = buildHttpCommandCmd(httpCmdType.plain, plainCmd);
     SendGetHttp(cmd);
 }
 
 function Apply_config_override() {
-    const cmd = buildHttpPlainCmd("M500");
+    const cmd = buildHttpCommandCmd(httpCmdType.plain, "M500");
     SendGetHttp(cmd, getESPUpdateconfigSuccess);
 }
 
 function Delete_config_override() {
-    const cmd = buildHttpPlainCmd("M502");
+    const cmd = buildHttpCommandCmd(httpCmdType.plain, "M502");
     SendGetHttp(cmd, getESPUpdateconfigSuccess);
 }
 
@@ -291,7 +291,7 @@ function configGetvalue(index, is_override) {
         config_lastindex_is_override = is_override;
         item.defaultvalue = value;
 
-        var cmd = buildHttpPlainCmd(`${item.cmd}${value}`);
+        var cmd = buildHttpCommandCmd(httpCmdType.plain, `${item.cmd}${value}`);
         SendGetHttp(cmd, setESPconfigSuccess, setESPconfigfailed);
     }
 }

--- a/www/js/config.js
+++ b/www/js/config.js
@@ -37,25 +37,24 @@ function config_display_override(display_it) {
     }
 }
 
-function getprinterconfig(is_override) {
-    var cmd = commandtxt;
-    if ((typeof is_override != 'undefined') && is_override) {
-        cmd = "M503";
+function getprinterconfig(is_override = false) {
+    const plainCmd = is_override ? "M503" : commandtxt;
+    is_override_config = is_override;
+    if (is_override) {
         config_override_List = [];
-        is_override_config = true;
-    } else is_override_config = false;
-    var url = "/command?plain=" + encodeURIComponent(cmd);
-    SendGetHttp(url);
+    }
+    const cmd = buildHttpPlainCmd(plainCmd);
+    SendGetHttp(cmd);
 }
 
 function Apply_config_override() {
-    var url = "/command?plain=" + encodeURIComponent("M500");
-    SendGetHttp(url, getESPUpdateconfigSuccess);
+    const cmd = buildHttpPlainCmd("M500");
+    SendGetHttp(cmd, getESPUpdateconfigSuccess);
 }
 
 function Delete_config_override() {
-    var url = "/command?plain=" + encodeURIComponent("M502");
-    SendGetHttp(url, getESPUpdateconfigSuccess);
+    const cmd = buildHttpPlainCmd("M502");
+    SendGetHttp(cmd, getESPUpdateconfigSuccess);
 }
 
 function getESPUpdateconfigSuccess(response) {
@@ -99,7 +98,7 @@ function build_HTML_config_list() {
             content += "<span class='input-group-addon hide_it' ></span>";
             content += "<input id='config_" + prefix + i + "' type='text' class='form-control' style='width:";
             content += "auto";
-            content += "'  value='" + item.defaultvalue + "' onkeyup='config_checkchange(" + i + "," + is_override_config + ")' />";
+            content += "' value='" + item.defaultvalue + "' onkeyup='config_checkchange(" + i + "," + is_override_config + ")' />";
             content += "<span id='icon_config_" + prefix + i + "'class='form-control-feedback ico_feedback' ></span>";
             content += "<span class='input-group-addon hide_it' ></span>";
             content += "</div>";
@@ -262,36 +261,38 @@ function is_config_override_file() {
 }
 
 function configGetvalue(index, is_override) {
-    var prefix = "";
-    var item = config_configList[index];
-    if (is_override) {
-        prefix = "_override";
-        item = config_override_List[index];
+    const prefix = is_override ? "_override" : "";
+    const item = is_override
+        ? config_override_List[index]
+        : config_configList[index];
+
+    const cnfId = `config_${prefix}${index}`;
+
+    // remove possible spaces
+    const value = id(cnfId).value.trim();
+    if (value === item.defaultvalue) {
+        return;
     }
-    //remove possible spaces
-    value = id('config_' + prefix + index).value.trim();
-    if (value == item.defaultvalue) return;
-    //check validity of value
-    var isvalid = config_check_value(value, index, is_override);
+
+    // check validity of value
+    const isvalid = config_check_value(value, index, is_override);
+
     //if not valid show error
+    id(`btn_${cnfId}`).className = `btn ${!isvalid ? "btn-danger" : "btn-success"}`;
+    id(`icon_${cnfId}`).className = `form-control-feedback ${!isvalid ? "has-error" : "has-success"} ico_feedback`;
+    id(`icon_${cnfId}`).innerHTML = isvalid ? get_icon_svg("remove") : get_icon_svg("ok");
+    id(`status_${cnfId}`).className = `form-group has-feedback ${!isvalid ? "has-error" : "has-success"}`;
+
     if (!isvalid) {
-        id('btn_config_' + prefix + index).className = "btn btn-danger";
-        id('icon_config_' + prefix + index).className = "form-control-feedback has-error ico_feedback";
-        id('icon_config_' + prefix + index).innerHTML = get_icon_svg("remove");
-        id('status_config_' + prefix + index).className = "form-group has-feedback has-error";
-        alertdlg(translate_text_item("Out of range"), translate_text_item("Value ") + config_error_msg + " !");
+        alertdlg(translate_text_item("Out of range"), `${translate_text_item("Value ")}${config_error_msg} !`);
     } else {
         //value is ok save it
-        var cmd = item.cmd + value;
         config_lastindex = index;
         config_lastindex_is_override = is_override;
         item.defaultvalue = value;
-        id('btn_config_' + prefix + index).className = "btn btn-success";
-        id('icon_config_' + prefix + index).className = "form-control-feedback has-success ico_feedback";
-        id('icon_config_' + prefix + index).innerHTML = get_icon_svg("ok");
-        id('status_config_' + prefix + index).className = "form-group has-feedback has-success";
-        var url = "/command?plain=" + encodeURIComponent(cmd);
-        SendGetHttp(url, setESPconfigSuccess, setESPconfigfailed);
+
+        var cmd = buildHttpPlainCmd(`${item.cmd}${value}`);
+        SendGetHttp(cmd, setESPconfigSuccess, setESPconfigfailed);
     }
 }
 

--- a/www/js/configtab.js
+++ b/www/js/configtab.js
@@ -2,7 +2,7 @@
 
 /** Set up the event handlers for the config tab */
 const configtab = () => {
-	id("config_refresh_btn").addEventListener("click", (event) => refreshconfig());
-	id("config_apply_override").addEventListener("click", (event) => Apply_config_override());
-	id("config_delete_override").addEventListener("click", (event) => Delete_config_override());
+	id("config_refresh_btn").addEventListener("click", refreshconfig);
+	id("config_apply_override").addEventListener("click", Apply_config_override);
+	id("config_delete_override").addEventListener("click", Delete_config_override);
 };

--- a/www/js/confirmdlg.js
+++ b/www/js/confirmdlg.js
@@ -1,5 +1,9 @@
 // import - closeModal, setactiveModal, showModal, id
 
+const confirmDlgCancel = () => closeModal("cancel");
+const confirmDlgYes = () => closeModal("yes");
+const confirmDlgNo = () => closeModal("no");
+
 /** confirm dialog */
 const confirmdlg = (titledlg, textdlg, closefunc) => {
 	const modal = setactiveModal("confirmdlg.html", closefunc);
@@ -7,9 +11,9 @@ const confirmdlg = (titledlg, textdlg, closefunc) => {
 		return;
 	}
 
-	id("ConfirmDialogClose").addEventListener("click", (event) => closeModal("cancel"));
-	id("ConfirmDialogYes").addEventListener("click", (event) => closeModal("yes"));
-	id("ConfirmDialogNo").addEventListener("click", (event) => closeModal("no"));
+	id("ConfirmDialogClose").addEventListener("click", confirmDlgCancel);
+	id("ConfirmDialogYes").addEventListener("click", confirmDlgYes);
+	id("ConfirmDialogNo").addEventListener("click", confirmDlgNo);
 
 	const title = modal.element.getElementsByClassName("modal-title")[0];
 	const body = modal.element.getElementsByClassName("modal-text")[0];

--- a/www/js/connectdlg.js
+++ b/www/js/connectdlg.js
@@ -130,6 +130,6 @@ const retryconnect = () => {
 
 	id("connectbtn").removeEventListener("click", retryconnect);
 
-	const cmd = buildHttpPlainCmd("[ESP800]");
+	const cmd = buildHttpCommandCmd(httpCmdType.plain, "[ESP800]");
 	SendGetHttp(cmd, connectsuccess, connectfailed);
 };

--- a/www/js/connectdlg.js
+++ b/www/js/connectdlg.js
@@ -130,6 +130,6 @@ const retryconnect = () => {
 
 	id("connectbtn").removeEventListener("click", retryconnect);
 
-	const url = `/command?plain=${encodeURIComponent("[ESP800]")}`;
-	SendGetHttp(url, connectsuccess, connectfailed);
+	const cmd = buildHttpPlainCmd("[ESP800]");
+	SendGetHttp(cmd, connectsuccess, connectfailed);
 };

--- a/www/js/controls.js
+++ b/www/js/controls.js
@@ -6,23 +6,31 @@ const init_controls_panel = () => {
 	loadmacrolist();
 };
 
+const controlsPanelZeroGrbl = () => SendZerocommand(grblzerocmd);
+const controlsPanelZeroX = () => SendZerocommand("X0");
+const controlsPanelZeroY = () => SendZerocommand("Y0");
+const controlsPanelZeroZ = () => SendZerocommand("Z0");
+const controlsPanelZeroA = () => SendZerocommand("A0");
+const controlsPanelZeroB = () => SendZerocommand("B0");
+const controlsPanelZeroC = () => SendZerocommand("C0");
+
 /** Set up the event handlers for the Controls Panel */
 const ControlsPanel = () => {
-	id("autocheck_position").addEventListener("click", (event) => on_autocheck_position());
-	id("controlpanel_interval_positions").addEventListener("change", (event) => onPosIntervalChange());
+	id("autocheck_position").addEventListener("click", on_autocheck_position);
+	id("controlpanel_interval_positions").addEventListener("change", onPosIntervalChange);
 
-	id("zero_xyz_btn").addEventListener("click", (event) => SendZerocommand(grblzerocmd));
-	id("zero_x_btn").addEventListener("click", (event) => SendZerocommand("X0"));
-	id("zero_y_btn").addEventListener("click", (event) => SendZerocommand("Y0"));
-	id("zero_z_btn").addEventListener("click", (event) => SendZerocommand("Z0"));
-	id("zero_a_btn").addEventListener("click", (event) => SendZerocommand("A0"));
-	id("zero_b_btn").addEventListener("click", (event) => SendZerocommand("B0"));
-	id("zero_c_btn").addEventListener("click", (event) => SendZerocommand("C0"));
+	id("zero_xyz_btn").addEventListener("click", controlsPanelZeroGrbl);
+	id("zero_x_btn").addEventListener("click", controlsPanelZeroX);
+	id("zero_y_btn").addEventListener("click", controlsPanelZeroY);
+	id("zero_z_btn").addEventListener("click", controlsPanelZeroZ);
+	id("zero_a_btn").addEventListener("click", controlsPanelZeroA);
+	id("zero_b_btn").addEventListener("click", controlsPanelZeroB);
+	id("zero_c_btn").addEventListener("click", controlsPanelZeroC);
 
-	id("controlpanel_xy_feedrate").addEventListener("change", (event) => onXYFeedRateChange());
-	id("controlpanel_z_feedrate").addEventListener("change", (event) => onNonXYFeedRateChange());
+	id("controlpanel_xy_feedrate").addEventListener("change", onXYFeedRateChange);
+	id("controlpanel_z_feedrate").addEventListener("change", onNonXYFeedRateChange);
 
-	id("motor_off_control").addEventListener("click", (event) => control_motorsOff());
+	id("motor_off_control").addEventListener("click", control_motorsOff);
 };
 
 function loadmacrolist() {

--- a/www/js/controls.js
+++ b/www/js/controls.js
@@ -27,8 +27,8 @@ const ControlsPanel = () => {
 
 function loadmacrolist() {
 	control_macrolist = [];
-	var url = "/macrocfg.json";
-	SendGetHttp(url, processMacroGetSuccess, processMacroGetFailed);
+	const cmd = buildHttpFileGetCmd("macrocfg.json");
+	SendGetHttp(cmd, processMacroGetSuccess, processMacroGetFailed);
 }
 
 function Macro_build_list(response_text) {

--- a/www/js/controls.js
+++ b/www/js/controls.js
@@ -249,13 +249,6 @@ function onNonXYFeedRateChange() {
 	control_changeaxis();
 }
 
-function processMacroSave(answer) {
-	if (answer == "ok") {
-		//console.log("now rebuild list");
-		control_build_macro_ui();
-	}
-}
-
 function control_build_macro_button(index, entry) {
 	const noGlyph = entry.glyph.length === 0;
 	const btnStyle = noGlyph ? " style='display:none'" : "";
@@ -268,13 +261,23 @@ function control_build_macro_button(index, entry) {
 	return content;
 }
 
+const processMacroSave = (answer) => {
+	if (answer !== "ok") {
+		return;
+	}
+	//console.log("now rebuild list");
+	control_build_macro_ui();
+}
+
+const initMacroDlg = () => showmacrodlg(processMacroSave);
+
 function control_build_macro_ui() {
 	const actions = [];
 
 	var content = "<div class='tooltip'>";
 	content += "<span class='tooltip-text'>Manage macros</span>"
 	content += "<button id='control_btn_show_macro_dlg' class='btn btn-primary'>";
-	actions.push({ id: "control_btn_show_macro_dlg", method: (event) => showmacrodlg(processMacroSave) });
+	actions.push({ id: "control_btn_show_macro_dlg", method: initMacroDlg});
 	content += "<span class='badge'>";
 	content += "<svg width='1.3em' height='1.2em' viewBox='0 0 1300 1200'>";
 	content += "<g transform='translate(50,1200) scale(1, -1)'>";

--- a/www/js/creditsdlg.js
+++ b/www/js/creditsdlg.js
@@ -1,5 +1,8 @@
 // import - closeModal, setactiveModal, showModal, id
 
+const creditsDlgCancel = () => closeModal("cancel");
+const creditsDlgClose = () => closeModal("Ok");
+
 //Credits dialog
 const creditsdlg = () => {
 	const modal = setactiveModal("creditsdlg.html");
@@ -7,8 +10,8 @@ const creditsdlg = () => {
 		return;
 	}
 
-	id("creditsDlgCancel").addEventListener("click", (event) => closeModal("cancel"));
-	id("creditsDlgClose").addEventListener("click", (event) => closeModal("Ok"));
+	id("creditsDlgCancel").addEventListener("click", creditsDlgCancel);
+	id("creditsDlgClose").addEventListener("click", creditsDlgClose);
 
 	showModal();
 };

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -196,7 +196,7 @@ function files_build_file_line(index, actions) {
 
 function files_print(index) {
 	const file = files_file_list[index];
-	const path = files_currentPath() + file.name;
+	const path = `${files_currentPath()}${file.name}`;
 	tabletSelectGCodeFile(file.name);
 	tabletLoadGCodeFile(path, file.size);
 	files_print_filename(path);

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -204,10 +204,10 @@ function process_files_Createdir(answer) {
 
 function files_create_dir(name) {
 	if (direct_sd) {
-		const cmdpath = files_currentPath;
-		const url = `/upload?path=${encodeURIComponent(cmdpath)}&action=createdir&filename=${encodeURIComponent(name)}`;
 		displayBlock("files_nav_loader");
-		SendGetHttp(url, files_list_success, files_list_failed);
+
+		const cmd = buildHttpFileCmd("createdir", name)
+		SendGetHttp(cmd, files_list_success, files_list_failed);
 	}
 }
 
@@ -228,16 +228,16 @@ function process_files_Delete(answer) {
 }
 
 function files_delete_file(index) {
-	files_error_status = `Delete ${files_file_list[index].name}`;
+	const fFile = files_file_list[index];
+	files_error_status = `Delete ${fFile.name}`;
 	if (!direct_sd) {
 		return;
 	}
-	const cmdpath = `path=${encodeURIComponent(files_currentPath)}`;
-	const action = `action=${files_file_list[index].isdir ? "deletedir" : "delete"}`;
-	const filename = `filename=${encodeURIComponent(files_file_list[index].sdname)}`;
-	const url = `/upload?${cmdpath}&${action}&${filename}`;
+
 	displayBlock("files_nav_loader");
-	SendGetHttp(url, files_list_success, files_list_failed);
+
+	const cmd = buildHttpFileCmd(fFile.isdir ? "deletedir" : "delete", fFile.sdname);
+	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 
 const files_is_clickable = (index) => files_file_list[index].isdir ? true : direct_sd;
@@ -257,13 +257,11 @@ function process_files_rename(new_file_name) {
 	}
 	files_error_status = `Rename ${old_file_name}`;
 
-	const cmdpath = `path=${encodeURIComponent(files_currentPath)}`;
-	const action = "action=rename";
-	const filename = `filename=${encodeURIComponent(old_file_name)}`;
-	const newname = `newname=${encodeURIComponent(new_file_name)}`;
-	const url = `/upload?${cmdpath}&${action}&${filename}&${newname}`;
 	displayBlock("files_nav_loader");
-	SendGetHttp(url, files_list_success, files_list_failed);
+
+	const newname = `newname=${encodeURIComponent(new_file_name)}`;
+	const cmd = `${buildHttpFileCmd("rename", old_file_name)}&${newname}`;
+	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 function files_download(index) {
 	const entry = files_file_list[index];
@@ -339,10 +337,11 @@ function files_refreshFiles(path, usecache) {
 	files_build_display_filelist(false);
 	displayBlock("files_list_loader");
 	displayBlock("files_nav_loader");
+
 	//this is pure direct SD
 	if (direct_sd) {
-		const url = `/upload?path=${encodeURI(cmdpath)}`;
-		SendGetHttp(url, files_list_success, files_list_failed);
+		const cmd = buildHttpFileCmd("", "", cmdpath);
+		SendGetHttp(cmd, files_list_success, files_list_failed);
 	}
 }
 
@@ -616,7 +615,7 @@ function files_start_upload() {
 		console.log("communication locked");
 		return;
 	}
-	const url = "/upload";
+
 	const path = files_currentPath;
 	//console.log("upload from " + path );
 	const files = id("files_input_file").files;
@@ -643,7 +642,7 @@ function files_start_upload() {
 	displayBlock("files_uploading_msg");
 	displayNone("files_navigation_buttons");
 	if (direct_sd) {
-		SendFileHttp(url, formData, FilesUploadProgressDisplay, files_list_success, files_directSD_upload_failed,);
+		SendFileHttp(httpCmd.fileUpload, formData, FilesUploadProgressDisplay, files_list_success, files_directSD_upload_failed,);
 		//console.log("send file");
 	}
 	id("files_input_file").value = "";

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -198,7 +198,7 @@ function files_build_file_line(index, actions) {
 
 function files_print(index) {
 	const file = files_file_list[index];
-	const path = files_currentPath() + file.name;
+	const path = `${files_currentPath()}${file.name}`;
 	tabletSelectGCodeFile(file.name);
 	tabletLoadGCodeFile(path, file.size);
 	files_print_filename(path);
@@ -284,7 +284,7 @@ function process_files_rename(new_file_name) {
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 
-const buildFileHref = (index) => encodeURIComponent(`SD/${files_currentPath}${files_file_list[index].sdname}`.replace("//", "/"));
+const buildFileHref = (index) => encodeURIComponent(`SD/${files_currentPath()}${files_file_list[index].sdname}`.replace("//", "/"));
 function files_download(index) {
 	//console.log("file on direct SD");
 	window.location.href = buildFileHref(index);
@@ -633,7 +633,7 @@ function files_start_upload() {
 		return;
 	}
 
-	const path = files_currentPath;
+	const path = files_currentPath();
 	//console.log("upload from " + path );
 	const files = id("files_input_file").files;
 

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -1,6 +1,16 @@
 // import - get_icon_svg, displayBlock, displayInline, displayNone, id, stdErrMsg, setHTML, alertdlg, confirmdlg, inputdlg, SendPrinterCommand, tryAutoReport, SendFileHttp, SendGetHttp, translate_text_item
 
-let files_currentPath = "/";
+let files_current_path = "/";
+/** get/set the current path used for files */
+const files_currentPath = (value) => {
+	if (typeof value === "string") {
+		files_current_path = value;
+	} else if (typeof value !== "string") {
+		files_current_path = "/";
+	}
+	return files_current_path;
+}
+
 let files_filter_sd_list = false;
 let files_file_list = [];
 let files_status_list = [];
@@ -54,48 +64,54 @@ function build_accept(file_filters_list) {
 	console.log(accept_txt);
 }
 
+const filesRefreshCurrent = () => files_refreshFiles(files_currentPath());
+const filesRefreshPrimarySD = () => files_refreshFiles(primary_sd);
+const filesRefreshSecondarySD = () => files_refreshFiles(secondary_sd);
+const filesRefreshPrinterSD = () => {
+	current_source = printer_sd;
+	files_refreshFiles(files_currentPath());
+}
+const filesRefreshTFTSD = () => {
+	current_source = tft_sd;
+	files_refreshFiles(files_currentPath());
+}
+const filesRefreshTFTUSB = () => {
+	current_source = tft_usb;
+	files_refreshFiles(files_currentPath());
+}
+
+/** Set up the event handlers for the files panel */
 function init_files_panel(dorefresh = true) {
 	displayInline("files_refresh_btn");
 	displayNone("files_refresh_primary_sd_btn");
 	displayNone("files_refresh_secondary_sd_btn");
 
-	id("files_createdir_btn").addEventListener("click", (event) => files_Createdir());
-	id("files_filter_btn").addEventListener("click", (event) => files_filter_button());
+	id("files_createdir_btn").addEventListener("click", files_Createdir);
+	id("files_filter_btn").addEventListener("click", files_filter_button);
 
-	id("files_refresh_btn").addEventListener("click", (event) => files_refreshFiles(files_currentPath));
-	id("files_refresh_primary_sd_btn").addEventListener("click", (event) => files_refreshFiles(primary_sd));
-	id("files_refresh_secondary_sd_btn").addEventListener("click", (event) => files_refreshFiles(secondary_sd));
+	id("files_refresh_btn").addEventListener("click", filesRefreshCurrent);
+	id("files_refresh_primary_sd_btn").addEventListener("click", filesRefreshPrimarySD);
+	id("files_refresh_secondary_sd_btn").addEventListener("click", filesRefreshSecondarySD);
 
-	id("files_refresh_printer_sd_btn").addEventListener("click", (event) => {
-		current_source = printer_sd;
-		files_refreshFiles(files_currentPath);
-	});
-	id("files_refresh_tft_sd_btn").addEventListener("click", (event) => {
-		current_source = tft_sd;
-		files_refreshFiles(files_currentPath);
-	});
-	id("files_refresh_tft_usb_btn").addEventListener("click", (event) => {
-		current_source = tft_usb;
-		files_refreshFiles(files_currentPath);
-	});
+	id("files_refresh_printer_sd_btn").addEventListener("click", filesRefreshPrinterSD);
+	id("files_refresh_tft_sd_btn").addEventListener("click", filesRefreshTFTSD);
+	id("files_refresh_tft_usb_btn").addEventListener("click", filesRefreshTFTUSB);
 
 	// TODO: Find out what happened to the `files_progress` method
-	// id('progress_btn').addEventListener('click', (event) => files_progress());
-	id("abort_btn").addEventListener("click", (event) => files_abort());
-	id("print_upload_btn").addEventListener("click", (event) => files_select_upload());
+	// id('progress_btn').addEventListener('click', files_progress);
+	id("abort_btn").addEventListener("click", files_abort);
+	id("print_upload_btn").addEventListener("click", files_select_upload);
 
 	initFilesInputFile();
 
 	files_set_button_as_filter(files_filter_sd_list);
 	if (direct_sd && dorefresh) {
-		files_refreshFiles(files_currentPath);
+		files_refreshFiles(files_currentPath());
 	}
 }
 
 /** Wire up the `files_input_file` handler */
-const initFilesInputFile = () => {
-	id("files_input_file").addEventListener("change", (event) => files_check_if_upload());
-}
+const initFilesInputFile = () => id("files_input_file").addEventListener("change", files_check_if_upload);
 
 const files_set_button_as_filter = (isfilter) => setHTML("files_filter_glyph", get_icon_svg(!isfilter ? "filter" : "list-alt", "1em", "1em"));
 
@@ -180,7 +196,7 @@ function files_build_file_line(index, actions) {
 
 function files_print(index) {
 	const file = files_file_list[index];
-	const path = files_currentPath + file.name;
+	const path = files_currentPath() + file.name;
 	tabletSelectGCodeFile(file.name);
 	tabletLoadGCodeFile(path, file.size);
 	files_print_filename(path);
@@ -203,12 +219,14 @@ function process_files_Createdir(answer) {
 }
 
 function files_create_dir(name) {
-	if (direct_sd) {
-		const cmdpath = files_currentPath;
-		const url = `/upload?path=${encodeURIComponent(cmdpath)}&action=createdir&filename=${encodeURIComponent(name)}`;
-		displayBlock("files_nav_loader");
-		SendGetHttp(url, files_list_success, files_list_failed);
+	if (!direct_sd) {
+		return;
 	}
+
+	const cmdpath = files_currentPath();
+	const url = `/upload?path=${encodeURIComponent(cmdpath)}&action=createdir&filename=${encodeURIComponent(name)}`;
+	displayBlock("files_nav_loader");
+	SendGetHttp(url, files_list_success, files_list_failed);
 }
 
 function files_delete(index) {
@@ -232,7 +250,7 @@ function files_delete_file(index) {
 	if (!direct_sd) {
 		return;
 	}
-	const cmdpath = `path=${encodeURIComponent(files_currentPath)}`;
+	const cmdpath = `path=${encodeURIComponent(files_currentPath())}`;
 	const action = `action=${files_file_list[index].isdir ? "deletedir" : "delete"}`;
 	const filename = `filename=${encodeURIComponent(files_file_list[index].sdname)}`;
 	const url = `/upload?${cmdpath}&${action}&${filename}`;
@@ -242,7 +260,7 @@ function files_delete_file(index) {
 
 const files_is_clickable = (index) => files_file_list[index].isdir ? true : direct_sd;
 
-const files_enter_dir = (name) => files_refreshFiles(`${files_currentPath + name}/`, true);
+const files_enter_dir = (name) => files_refreshFiles(`${files_currentPath()}${name}/`, true);
 
 let old_file_name;
 function files_rename(index) {
@@ -257,7 +275,7 @@ function process_files_rename(new_file_name) {
 	}
 	files_error_status = `Rename ${old_file_name}`;
 
-	const cmdpath = `path=${encodeURIComponent(files_currentPath)}`;
+	const cmdpath = `path=${encodeURIComponent(files_currentPath())}`;
 	const action = "action=rename";
 	const filename = `filename=${encodeURIComponent(old_file_name)}`;
 	const newname = `newname=${encodeURIComponent(new_file_name)}`;
@@ -268,7 +286,7 @@ function process_files_rename(new_file_name) {
 function files_download(index) {
 	const entry = files_file_list[index];
 	//console.log("file on direct SD");
-	const url = `SD/${files_currentPath}${entry.sdname}`;
+	const url = `SD/${files_currentPath()}${entry.sdname}`;
 	window.location.href = encodeURIComponent(url.replace("//", "/"));
 }
 function files_click_file(index) {
@@ -280,7 +298,7 @@ function files_click_file(index) {
 	if (false && direct_sd) {
 		// Don't download on click; use the button
 		//console.log("file on direct SD");
-		const url = `SD/${files_currentPath}${entry.sdname}`;
+		const url = `SD/${files_currentPath()}${entry.sdname}`;
 		window.location.href = encodeURIComponent(url.replace("//", "/"));
 		return;
 	}
@@ -319,9 +337,9 @@ function files_showdeletebutton(index) {
 function files_refreshFiles(path, usecache) {
 	//console.log("refresh requested " + path);
 	const cmdpath = path;
-	files_currentPath = path;
+	files_currentPath(path);
 	if (current_source !== last_source) {
-		files_currentPath = "/";
+		files_currentPath("/");
 		path = "/";
 		last_source = current_source;
 	}
@@ -333,7 +351,7 @@ function files_refreshFiles(path, usecache) {
 	if (typeof usecache === "undefined") {
 		usecache = false;
 	}
-	setHTML("files_currentPath", files_currentPath);
+	setHTML("files_currentPath", files_currentPath());
 	files_file_list = [];
 	files_status_list = [];
 	files_build_display_filelist(false);
@@ -480,10 +498,10 @@ function files_directSD_upload_failed(error_code, response) {
 	displayBlock("files_navigation_buttons");
 }
 
-const need_up_level = () => files_currentPath !== "/";
+const need_up_level = () => files_currentPath() !== "/";
 
 function files_go_levelup() {
-	const tlist = files_currentPath.split("/");
+	const tlist = files_currentPath().split("/");
 	let path = "/";
 	let nb = 1;
 	while (nb < tlist.length - 2) {
@@ -494,7 +512,7 @@ function files_go_levelup() {
 }
 
 function files_build_display_filelist(displaylist = true) {
-	populateTabletFileSelector(files_file_list, files_currentPath);
+	populateTabletFileSelector(files_file_list, files_currentPath());
 
 	displayNone("files_uploading_msg");
 	displayNone("files_list_loader");
@@ -541,7 +559,7 @@ function files_build_display_filelist(displaylist = true) {
 	if (files_status_list.length === 0 && files_error_status !== "") {
 		files_status_list.push({
 			status: files_error_status,
-			path: files_currentPath,
+			path: files_currentPath(),
 			used: "-1",
 			total: "-1",
 			occupation: "-1",
@@ -617,7 +635,7 @@ function files_start_upload() {
 		return;
 	}
 	const url = "/upload";
-	const path = files_currentPath;
+	const path = files_currentPath();
 	//console.log("upload from " + path );
 	const files = id("files_input_file").files;
 

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -238,7 +238,8 @@ function files_delete_file(index) {
 
 	displayBlock("files_nav_loader");
 
-	const cmd = buildHttpFileCmd({ action: fFile.isdir ? "deletedir" : "delete", filename: fFile.sdname });
+	const action = fFile.isdir ? "deletedir" : "delete";
+	const cmd = buildHttpFileCmd({ action: action, filename: fFile.sdname });
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 
@@ -264,11 +265,11 @@ function process_files_rename(new_file_name) {
 	const cmd = buildHttpFileCmd({ action: "rename", filename: old_file_name, newname: new_file_name });
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
+
+const buildFileHref = (index) => encodeURIComponent(`SD/${files_currentPath}${files_file_list[index].sdname}`.replace("//", "/"));
 function files_download(index) {
-	const entry = files_file_list[index];
 	//console.log("file on direct SD");
-	const url = `SD/${files_currentPath}${entry.sdname}`;
-	window.location.href = encodeURIComponent(url.replace("//", "/"));
+	window.location.href = buildFileHref(index);
 }
 function files_click_file(index) {
 	const entry = files_file_list[index];
@@ -279,8 +280,7 @@ function files_click_file(index) {
 	if (false && direct_sd) {
 		// Don't download on click; use the button
 		//console.log("file on direct SD");
-		const url = `SD/${files_currentPath}${entry.sdname}`;
-		window.location.href = encodeURIComponent(url.replace("//", "/"));
+		window.location.href = buildFileHref(index);
 		return;
 	}
 }
@@ -641,7 +641,7 @@ function files_start_upload() {
 	displayBlock("files_uploading_msg");
 	displayNone("files_navigation_buttons");
 	if (direct_sd) {
-		SendFileHttp(httpCmd.fileUpload, formData, FilesUploadProgressDisplay, files_list_success, files_directSD_upload_failed,);
+		SendFileHttp(httpCmd.fileUpload, formData, FilesUploadProgressDisplay, files_list_success, files_directSD_upload_failed);
 		//console.log("send file");
 	}
 	id("files_input_file").value = "";

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -230,11 +230,11 @@ function process_files_Delete(answer) {
 }
 
 function files_delete_file(index) {
-	const fFile = files_file_list[index];
-	files_error_status = `Delete ${fFile.name}`;
-	if (!direct_sd) {
+	if (!direct_sd || (files_file_list.length - 1) < index) {
 		return;
 	}
+	const fFile = files_file_list[index];
+	files_error_status = `Delete ${fFile.name}`;
 
 	displayBlock("files_nav_loader");
 

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -38,7 +38,9 @@ function build_accept(file_filters_list) {
 		for (let i = 0; i < tfiles_filters.length; i++) {
 			const v = tfiles_filters[i].trim();
 			if (v.length > 0) {
-				if (accept_txt.length > 0) accept_txt += ", ";
+				if (accept_txt.length > 0) {
+					accept_txt += ", ";
+				}
 				accept_txt += `.${v}`;
 			}
 		}
@@ -206,7 +208,7 @@ function files_create_dir(name) {
 	if (direct_sd) {
 		displayBlock("files_nav_loader");
 
-		const cmd = buildHttpFileCmd("createdir", name)
+		const cmd = buildHttpFileCmd({ action: "createdir", filename: name });
 		SendGetHttp(cmd, files_list_success, files_list_failed);
 	}
 }
@@ -236,7 +238,7 @@ function files_delete_file(index) {
 
 	displayBlock("files_nav_loader");
 
-	const cmd = buildHttpFileCmd(fFile.isdir ? "deletedir" : "delete", fFile.sdname);
+	const cmd = buildHttpFileCmd({ action: fFile.isdir ? "deletedir" : "delete", filename: fFile.sdname });
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 
@@ -259,8 +261,7 @@ function process_files_rename(new_file_name) {
 
 	displayBlock("files_nav_loader");
 
-	const newname = `newname=${encodeURIComponent(new_file_name)}`;
-	const cmd = `${buildHttpFileCmd("rename", old_file_name)}&${newname}`;
+	const cmd = buildHttpFileCmd({ action: "rename", filename: old_file_name, newname: new_file_name });
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 function files_download(index) {
@@ -340,7 +341,7 @@ function files_refreshFiles(path, usecache) {
 
 	//this is pure direct SD
 	if (direct_sd) {
-		const cmd = buildHttpFileCmd("", "", cmdpath);
+		const cmd = buildHttpFileCmd({ path: cmdpath });
 		SendGetHttp(cmd, files_list_success, files_list_failed);
 	}
 }
@@ -582,8 +583,6 @@ const files_select_upload = () => {
 }
 
 function files_check_if_upload() {
-	const canupload = true;
-	const files = id("files_input_file").files;
 	if (direct_sd) {
 		SendPrinterCommand("[ESP200]", false, process_check_sd_presence);
 	} else {
@@ -620,7 +619,7 @@ function files_start_upload() {
 	//console.log("upload from " + path );
 	const files = id("files_input_file").files;
 
-	if (files.value === "" || typeof files[0].name === "undefined") {
+	if (!files.length || typeof files[0].name === "undefined") {
 		console.log("nothing to upload");
 		return;
 	}

--- a/www/js/grblpanel.js
+++ b/www/js/grblpanel.js
@@ -1,65 +1,88 @@
 // import - id, opentab, SendPrinterCommand, grbl_reset, reportNone, tryAutoReport, reportPolled, onAutoReportIntervalChange, onstatusIntervalChange, onprobemaxtravelChange, onprobefeedrateChange, onproberetractChange, onprobetouchplatethicknessChange, SendRealtimeCmd, StartProbeProcess
 
+const grblPanelClearStatus = () => SendPrinterCommand("$X", true, null, null, 114, 1);
+const grblPanelPause = () => SendRealtimeCmd(0x21);
+const grblPanelResume = () => SendRealtimeCmd(0x7e);
+
+const grblPanelF10Minus = () => SendRealtimeCmd(0x92);
+const grblPanelF1Minus = () => SendRealtimeCmd(0x94);
+const grblPanelF0 = () => SendRealtimeCmd(0x90);
+const grblPanelF1Plus = () => SendRealtimeCmd(0x93);
+const grblPanelF10Plus = () => SendRealtimeCmd(0x91);
+
+const grblPanelS10Minus = () => SendRealtimeCmd(0x9b);
+const grblPanelS1Minus = () => SendRealtimeCmd(0x9d);
+const grblPanelS0 = () => SendRealtimeCmd(0x99);
+const grblPanelS1Plus = () => SendRealtimeCmd(0x9c);
+const grblPanelS10Plus = () => SendRealtimeCmd(0x9a);
+
+const grblPanelSpindle = () => SendRealtimeCmd(0x9e);
+const grblPanelFlood = () => SendRealtimeCmd(0xa0);
+const grblPanelMist = () => SendRealtimeCmd(0xa1);
+
+const grblPanelSpindleFwd = () => SendPrinterCommand(`M3 S${spindleTabSpindleSpeed}`, false, null, null, 1, 1);
+const grblPanelSpindleRew = () => SendPrinterCommand(`M4 S${spindleTabSpindleSpeed}`, false, null, null, 1, 1);
+const grblPanelSpindleOff = () => SendPrinterCommand("M5 S0", false, null, null, 1, 1);
+const grblPanelSpindleRpm = (event) => setSpindleSpeed(event.value);
+
+const grblPanelControlTabLink = (event) => opentab(event, "grblcontroltab", "grbluitabscontent", "grbluitablinks");
+const grblPanelSpindleTabLink = (event) => opentab(event, "grblspindletab", "grbluitabscontent", "grbluitablinks");
+const grblPanelProbeTabLink = (event) => opentab(event, "grblprobetab", "grbluitabscontent", "grbluitablinks");
+
 /** Set up the event handlers for the grblpanel */
 const grblpanel = () => {
     // GRBL reporting
-    id("report_none").addEventListener("change", (event) => onReportType(event));
-    id("report_auto").addEventListener("change", (event) => onReportType(event));
-    id("grblpanel_autoreport_interval").addEventListener("change", (event) => onAutoReportIntervalChange());
-    id("report_poll").addEventListener("change", (event) => onReportType(event));
-    id("grblpanel_interval_status").addEventListener("change", (event) => onstatusIntervalChange());
+    id("report_none").addEventListener("change", onReportType);
+    id("report_auto").addEventListener("change", onReportType);
+    id("grblpanel_autoreport_interval").addEventListener("change", onAutoReportIntervalChange);
+    id("report_poll").addEventListener("change", onReportType);
+    id("grblpanel_interval_status").addEventListener("change", onstatusIntervalChange);
 
-    id("clear_status_btn").addEventListener("click", (event) => SendPrinterCommand("$X", true, null, null, 114, 1));
-    id("sd_pause_btn").addEventListener("click", (event) => SendRealtimeCmd(0x21));
-    id("sd_resume_btn").addEventListener("click", (event) => SendRealtimeCmd(0x7e));
-    id("sd_reset_btn").addEventListener("click", (event) => grbl_reset());
+    id("clear_status_btn").addEventListener("click", grblPanelClearStatus);
+    id("sd_pause_btn").addEventListener("click", grblPanelPause);
+    id("sd_resume_btn").addEventListener("click", grblPanelResume);
+    id("sd_reset_btn").addEventListener("click", grbl_reset);
 
-    id("grblpanel_F10_minus").addEventListener("click", (event) => SendRealtimeCmd(0x92));
-    id("grblpanel_F1_minus").addEventListener("click", (event) => SendRealtimeCmd(0x94));
-    id("grblpanel_F0").addEventListener("click", (event) => SendRealtimeCmd(0x90));
-    id("grblpanel_F1_plus").addEventListener("click", (event) => SendRealtimeCmd(0x93));
-    id("grblpanel_F10_plus").addEventListener("click", (event) => SendRealtimeCmd(0x91));
+    id("grblpanel_F10_minus").addEventListener("click", grblPanelF10Minus);
+    id("grblpanel_F1_minus").addEventListener("click", grblPanelF1Minus);
+    id("grblpanel_F0").addEventListener("click", grblPanelF0);
+    id("grblpanel_F1_plus").addEventListener("click", grblPanelF1Plus);
+    id("grblpanel_F10_plus").addEventListener("click", grblPanelF10Plus);
 
-    id("grblpanel_S10_minus").addEventListener("click", (event) => SendRealtimeCmd(0x9b));
-    id("grblpanel_S1_minus").addEventListener("click", (event) => SendRealtimeCmd(0x9d));
-    id("grblpanel_S0").addEventListener("click", (event) => SendRealtimeCmd(0x99));
-    id("grblpanel_S1_plus").addEventListener("click", (event) => SendRealtimeCmd(0x9c));
-    id("grblpanel_S10_plus").addEventListener("click", (event) => SendRealtimeCmd(0x9a));
+    id("grblpanel_S10_minus").addEventListener("click", grblPanelS10Minus);
+    id("grblpanel_S1_minus").addEventListener("click", grblPanelS1Minus);
+    id("grblpanel_S0").addEventListener("click", grblPanelS0);
+    id("grblpanel_S1_plus").addEventListener("click", grblPanelS1Plus);
+    id("grblpanel_S10_plus").addEventListener("click", grblPanelS10Plus);
 
-    id("grblpanel_spindle").addEventListener("click", (event) => SendRealtimeCmd(0x9e));
-    id("grblpanel_flood").addEventListener("click", (event) => SendRealtimeCmd(0xa0));
-    id("grblpanel_mist").addEventListener("click", (event) => SendRealtimeCmd(0xa1));
+    id("grblpanel_spindle").addEventListener("click", grblPanelSpindle);
+    id("grblpanel_flood").addEventListener("click", grblPanelFlood);
+    id("grblpanel_mist").addEventListener("click", grblPanelMist);
 
-    id("grblspindle_fwd").addEventListener("click", (event) => SendPrinterCommand(`M3 S${spindleTabSpindleSpeed}`, false, null, null, 1, 1,));
-    id("grblspindle_rew").addEventListener("click", (event) => SendPrinterCommand(`M4 S${spindleTabSpindleSpeed}`, false, null, null, 1, 1,));
-    id("grblspindle_off").addEventListener("click", (event) => SendPrinterCommand("M5 S0", false, null, null, 1, 1));
-    id("grblspindle_rpm").addEventListener("change", (event) => setSpindleSpeed(event.value));
-    id("grblspindle_rpm").addEventListener("keyup", (event) => setSpindleSpeed(event.value));
+    id("grblspindle_fwd").addEventListener("click", grblPanelSpindleFwd);
+    id("grblspindle_rew").addEventListener("click", grblPanelSpindleRew);
+    id("grblspindle_off").addEventListener("click", grblPanelSpindleOff);
+    id("grblspindle_rpm").addEventListener("change", grblPanelSpindleRpm);
+    id("grblspindle_rpm").addEventListener("keyup", grblPanelSpindleRpm);
 
-    id("grblpanel_probemaxtravel").addEventListener("change", (event) => onprobemaxtravelChange());
-    id("grblpanel_probefeedrate").addEventListener("change", (event) => onprobefeedrateChange());
-    id("grblpanel_proberetract").addEventListener("change", (event) => onproberetractChange());
-    id("grblpanel_probetouchplatethickness").addEventListener("change", (event) => onprobetouchplatethicknessChange());
+    id("grblpanel_probemaxtravel").addEventListener("change", onprobemaxtravelChange);
+    id("grblpanel_probefeedrate").addEventListener("change", onprobefeedrateChange);
+    id("grblpanel_proberetract").addEventListener("change", onproberetractChange);
+    id("grblpanel_probetouchplatethickness").addEventListener("change", onprobetouchplatethicknessChange);
 
-    id("probingbtn").addEventListener("click", (event) => StartProbeProcess());
+    id("probingbtn").addEventListener("click", StartProbeProcess);
 
-    id("grblcontroltablink").addEventListener("click", (event) => opentab(event, "grblcontroltab", "grbluitabscontent", "grbluitablinks"));
-    id("grblspindletablink").addEventListener("click", (event) => opentab(event, "grblspindletab", "grbluitabscontent", "grbluitablinks"));
-    id("grblpanel_probetablink").addEventListener("click", (event) => opentab(event, "grblprobetab", "grbluitabscontent", "grbluitablinks"));
+    id("grblcontroltablink").addEventListener("click", grblPanelControlTabLink);
+    id("grblspindletablink").addEventListener("click", grblPanelSpindleTabLink);
+    id("grblpanel_probetablink").addEventListener("click", grblPanelProbeTabLink);
 
-    id("global_reset_btn").addEventListener("click", (event) => grbl_reset());
+    id("global_reset_btn").addEventListener("click", grbl_reset);
 };
 
 const onReportType = (e) => {
     switch (e.value) {
-        case "none":
-            reportNone();
-            break;
-        case "auto":
-            tryAutoReport();
-            break;
-        case "poll":
-            reportPolled();
-            break;
+        case "none": reportNone(); break;
+        case "auto": tryAutoReport(); break;
+        case "poll": reportPolled(); break;
     }
 };

--- a/www/js/http.js
+++ b/www/js/http.js
@@ -143,10 +143,10 @@ function ProcessGetHttp(url, resultfn, errorfn) {
         if (xmlhttp.readyState == 4) {
             if (xmlhttp.status == 200) {
                 //console.log("*** " + url + " done");
-                if (typeof resultfn != 'undefined' && resultfn != null) resultfn(xmlhttp.responseText);
+                if (typeof resultfn === "function") resultfn(xmlhttp.responseText);
             } else {
                 if (xmlhttp.status == 401) GetIdentificationStatus();
-                if (typeof errorfn != 'undefined' && errorfn != null) errorfn(xmlhttp.status, xmlhttp.responseText);
+                if (typeof errorfn === "function") errorfn(xmlhttp.status, xmlhttp.responseText);
             }
         }
     }
@@ -200,10 +200,10 @@ function ProcessPostHttp(url, postdata, resultfn, errorfn) {
     xmlhttp.onreadystatechange = function() {
         if (xmlhttp.readyState == 4) {
             if (xmlhttp.status == 200) {
-                if (typeof resultfn != 'undefined' && resultfn != null) resultfn(xmlhttp.responseText);
+                if (typeof resultfn === "function") resultfn(xmlhttp.responseText);
             } else {
                 if (xmlhttp.status == 401) GetIdentificationStatus();
-                if (typeof errorfn != 'undefined' && errorfn != null) errorfn(xmlhttp.status, xmlhttp.responseText);
+                if (typeof errorfn === "function") errorfn(xmlhttp.status, xmlhttp.responseText);
             }
         }
     }
@@ -245,15 +245,17 @@ function ProcessFileHttp(url, postdata, progressfn, resultfn, errorfn) {
         if (xmlhttpupload.readyState == 4) {
             http_communication_locked = false;
             if (xmlhttpupload.status == 200) {
-                if (typeof resultfn != 'undefined' && resultfn != null) resultfn(xmlhttpupload.responseText);
+                if (typeof resultfn === "function") resultfn(xmlhttpupload.responseText);
             } else {
                 if (xmlhttpupload.status == 401) GetIdentificationStatus();
-                if (typeof errorfn != 'undefined' && errorfn != null) errorfn(xmlhttpupload.status, xmlhttpupload.responseText);
+                if (typeof errorfn === "function") errorfn(xmlhttpupload.status, xmlhttpupload.responseText);
             }
         }
     }
     //console.log(url);
     xmlhttpupload.open("POST", url, true);
-    if (typeof progressfn != 'undefined' && progressfn != null) xmlhttpupload.upload.addEventListener("progress", progressfn, false);
+    if (typeof progressfn === "function") {
+        xmlhttpupload.upload.addEventListener("progress", progressfn, false);
+    }
     xmlhttpupload.send(postdata);
 }

--- a/www/js/httpCmdBuilders.js
+++ b/www/js/httpCmdBuilders.js
@@ -1,0 +1,119 @@
+// Various helper methods for building http commands
+
+var page_id = ""
+
+/** 'Commands' to be sent as the first part of the URL after the host name */
+const httpCmd = {
+    command: "/command",
+    fileGet: "/",
+    /** Perform a GET file action. Mostly used by files.js (i.e. not SPIFFs) */
+    fileUpload: "/upload",
+    /** Perform a files action.
+     * For a POST this is used with FormData.
+     * For a GET this is used with parameters */
+    files: "/files",
+    /** Perform a firmware action.
+     * For a POST this is used with FormData the firmware.
+     * For a GET this this does something else? */
+    fwUpdate: "/updatefw",
+    /** Perform some auth related GET action */
+    login: "/login",
+};
+
+/** Command Types for the http `/command` command */
+const httpCmdType = {
+    "plain": "plain",
+    "commandText": "commandText"
+};
+
+/** Extract a named parameter value from the supplied params value,
+ * if it's falsey use the defaultValue */
+const getParam = (params, paramName, defaultValue = "") => {
+    return (paramName in params && params[paramName].trim())
+        ? params[paramName].trim()
+        : defaultValue;
+}
+
+/** Build a full `/login` GET command, encoding the supplied params excluding DISCONNECT (and SUBMIT) */
+const buildHttpLoginCmd = (params = { }) => {
+    const cmd = [];
+    // Do a deep copy of the params
+    let prms = JSON.parse(JSON.stringify(params));
+
+    if ("DISCONNECT" in prms && prms.DISCONNECT === "yes") {
+        // Disconnect - throw away any other parameters
+        prms = {"DISCONNECT": "yes"};
+    } else {
+        // Login / Change Password - add the submit param
+        prms.SUBMIT = "yes";
+    }
+
+    Object.keys(prms).forEach((key) => {
+        let pVal = getParam(prms, key);
+        if (pVal) {
+            if (!["DISCONNECT", "SUBMIT"].includes(key)) {
+                pVal = encodeURIComponent(pVal);
+            }
+            if (cmd.length) {
+                cmd.push(`${key}=${pVal}`);
+            } else {
+                cmd.push(`${httpCmd.login}?${key}=${pVal}`);
+            }
+        }
+    });
+
+    return cmd.join("&");
+}
+
+/** Build a full `/files` GET command, encoding all the supplied params excluding `action` */
+const buildHttpFilesCmd = (params = { }) => {
+    const cmd = [];
+
+    Object.keys(params).forEach((key) => {
+        let pVal = getParam(params, key);
+        if (pVal) {
+            if (!["action"].includes(key)) {
+                pVal = encodeURIComponent(pVal);
+            }
+            if (cmd.length) {
+                cmd.push(`${key}=${pVal}`);
+            } else {
+                cmd.push(`${httpCmd.login}?${key}=${pVal}`);
+            }
+        }
+    });
+
+    return cmd.join("&");
+}
+
+/** Build a full `/upload` GET command, encoding the supplied `name`, `newname` and `path` values */
+const buildHttpFileCmd = (params = { action: "", path: "", filename: "" }) => {
+    // `path` is special, it always goes into the command, and it always goes first
+    const path = getParam(params, "path", files_currentPath);
+    const cmdInfo = [`Performing http '${httpCmd.fileUpload}' GET command for path:'${path}'`];
+    const cmd = [`${httpCmd.fileUpload}?path=${encodeURIComponent(path)}`];
+
+    Object.keys(params).forEach((key) => {
+        if (key !== "path") {
+            let pVal = getParam(params, key);
+            if (pVal) {
+                cmdInfo.push(`with ${key}:'${pVal}'`);
+                if (["name", "newname"].includes(key)) {
+                    pVal = encodeURIComponent(pVal);
+                }
+                cmd.push(`${key}=${pVal}`);
+            }
+        }
+    });
+
+    console.info(cmdInfo.join(" "));
+    return cmd.join("&");
+}
+
+/** Build a simple file GET command. For some reason the filename is not encoded */
+const buildHttpFileGetCmd = (filename) => `${httpCmd.fileGet}${filename}`;
+
+/** Build either form of the `command` GET command, fully encoding the supplied `cmd` value.
+ * * Note: this includes replacing '#', because '#' is not encoded by `encodeURIComponent`.
+ */
+const buildHttpCommandCmd = (cmdType, cmd) => `${httpCmd.command}?${cmdType}=${encodeURIComponent(cmd).replace("#", "%23")}&PAGEID=${page_id}`;

--- a/www/js/httpCmdBuilders.js
+++ b/www/js/httpCmdBuilders.js
@@ -78,7 +78,7 @@ const buildHttpFilesCmd = (params = { }) => {
             if (cmd.length) {
                 cmd.push(`${key}=${pVal}`);
             } else {
-                cmd.push(`${httpCmd.login}?${key}=${pVal}`);
+                cmd.push(`${httpCmd.files}?${key}=${pVal}`);
             }
         }
     });
@@ -89,7 +89,7 @@ const buildHttpFilesCmd = (params = { }) => {
 /** Build a full `/upload` GET command, encoding the supplied `name`, `newname` and `path` values */
 const buildHttpFileCmd = (params = { action: "", path: "", filename: "" }) => {
     // `path` is special, it always goes into the command, and it always goes first
-    const path = getParam(params, "path", files_currentPath);
+    const path = getParam(params, "path", files_currentPath());
     const cmdInfo = [`Performing http '${httpCmd.fileUpload}' GET command for path:'${path}'`];
     const cmd = [`${httpCmd.fileUpload}?path=${encodeURIComponent(path)}`];
 

--- a/www/js/initUI.js
+++ b/www/js/initUI.js
@@ -35,7 +35,7 @@ const update_UI_firmware_target = () => {
 
 	const fif = id("files_input_file");
 	if (fif) {
-		fif.accept = " .g, .gco, .gcode, .txt, .ncc, .G, .GCO, .GCODE, .TXT, .NC";
+		fif.accept = ".g,.gco,.gcode,.txt,.nc,.G,.GCO,.GCODE,.TXT,.NC";
 	}
 	displayInitial("zero_xyz_btn");
 	displayInitial("zero_x_btn");

--- a/www/js/inputdlg.js
+++ b/www/js/inputdlg.js
@@ -1,5 +1,8 @@
 // import - closeModal, setactiveModal, showModal, id
 
+const inputDlgCancel = () => closeModal("cancel");
+const inputDlgClose = () => closeModal("Ok");
+
 //input dialog
 const inputdlg = (titledlg, textdlg, closefunc, preset = "") => {
 	const modal = setactiveModal("inputdlg.html", closefunc);
@@ -7,9 +10,9 @@ const inputdlg = (titledlg, textdlg, closefunc, preset = "") => {
 		return;
 	}
 
-	id("inputdlg_close").addEventListener("click", (event) => closeInputModal("cancel"));
-	id("inputdlg_cancel").addEventListener("click", (event) => closeInputModal("cancel"));
-	id("inputdlg_ok").addEventListener("click", (event) => closeInputModal("ok"));
+	id("inputdlg_close").addEventListener("click", inputDlgCancel);
+	id("inputdlg_cancel").addEventListener("click", inputDlgCancel);
+	id("inputdlg_ok").addEventListener("click", inputDlgClose);
 
 	const title = modal.element.getElementsByClassName("modal-title")[0];
 	const body = modal.element.getElementsByClassName("modal-text")[0];

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -91,7 +91,7 @@ function SubmitLogin() {
 	displayNone("login_content");
 	displayBlock("login_loader");
 
-	const cmd = buildHttpLoginCmd({"USER": user, "PASSWORD": password});
+	const cmd = buildHttpLoginCmd({ USER: user, PASSWORD: password });
 	SendGetHttp(cmd, loginsuccess, loginfailed);
 }
 
@@ -114,7 +114,7 @@ function DisconnectionFailed(error_code, response) {
 
 function DisconnectLogin(answer) {
 	if (answer === "yes") {
-		const cmd = buildHttpLoginCmd({"DISCONNECT": answer});
+		const cmd = buildHttpLoginCmd({ DISCONNECT: answer });
 		SendGetHttp(cmd, DisconnectionSuccess, DisconnectionFailed);
 	}
 }

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -16,8 +16,7 @@ const logindlg = (closefunc, check_first = false) => {
 	displayBlock("login_content");
 
 	if (check_first) {
-		const url = "/login";
-		SendGetHttp(url, checkloginsuccess);
+		SendGetHttp(httpCmd.login, checkloginsuccess);
 	} else {
 		showModal();
 	}
@@ -85,14 +84,14 @@ function loginsuccess(response_text) {
 
 function SubmitLogin() {
 	const user = id("login_user_text").value.trim();
-	const password = id("login_password_text").value.trim();
-	const url =
-		`/login?USER=${encodeURIComponent(user)}&PASSWORD=${encodeURIComponent(password)}&SUBMIT=yes`;
+	const userEnc = encodeURIComponent(user);
+	const password = encodeURIComponent(id("login_password_text").value.trim());
+	const cmd = `${httpCmd.login}?USER=${userEnc}&PASSWORD=${password}&SUBMIT=yes`;
 	setHTML("current_ID", user);
 	setHTML("current_auth_level", "");
 	displayNone("login_content");
 	displayBlock("login_loader");
-	SendGetHttp(url, loginsuccess, loginfailed);
+	SendGetHttp(cmd, loginsuccess, loginfailed);
 }
 
 function DisconnectionSuccess(response_text) {
@@ -114,7 +113,7 @@ function DisconnectionFailed(error_code, response) {
 
 function DisconnectLogin(answer) {
 	if (answer === "yes") {
-		const url = "/login?DISCONNECT=yes";
-		SendGetHttp(url, DisconnectionSuccess, DisconnectionFailed);
+		const cmd = `${httpCmd.login}?DISCONNECT=yes`;
+		SendGetHttp(cmd, DisconnectionSuccess, DisconnectionFailed);
 	}
 }

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -7,9 +7,9 @@ const logindlg = (closefunc, check_first = false) => {
 		return;
 	}
 
-	id("login_user_text").addEventListener("keyup", (event) => login_id_OnKeyUp(event));
-	id("login_password_text").addEventListener("keyup", (event) => login_password_OnKeyUp(event));
-	id("login_submit_btn").addEventListener("click", (event) => SubmitLogin());
+	id("login_user_text").addEventListener("keyup", login_id_OnKeyUp);
+	id("login_password_text").addEventListener("keyup", login_password_OnKeyUp);
+	id("login_submit_btn").addEventListener("click", SubmitLogin);
 
 	setHTML("login_title", translate_text_item("Identification requested"));
 	displayNone("login_loader");

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -84,13 +84,14 @@ function loginsuccess(response_text) {
 
 function SubmitLogin() {
 	const user = id("login_user_text").value.trim();
-	const userEnc = encodeURIComponent(user);
-	const password = encodeURIComponent(id("login_password_text").value.trim());
-	const cmd = `${httpCmd.login}?USER=${userEnc}&PASSWORD=${password}&SUBMIT=yes`;
+	const password = id("login_password_text").value.trim();
+
 	setHTML("current_ID", user);
 	setHTML("current_auth_level", "");
 	displayNone("login_content");
 	displayBlock("login_loader");
+
+	const cmd = buildHttpLoginCmd({"USER": user, "PASSWORD": password});
 	SendGetHttp(cmd, loginsuccess, loginfailed);
 }
 
@@ -113,7 +114,7 @@ function DisconnectionFailed(error_code, response) {
 
 function DisconnectLogin(answer) {
 	if (answer === "yes") {
-		const cmd = `${httpCmd.login}?DISCONNECT=yes`;
+		const cmd = buildHttpLoginCmd({"DISCONNECT": answer});
 		SendGetHttp(cmd, DisconnectionSuccess, DisconnectionFailed);
 	}
 }

--- a/www/js/macrodlg.js
+++ b/www/js/macrodlg.js
@@ -301,21 +301,21 @@ function SaveNewMacroList() {
 		}
 	}
 
-	const blob = new Blob([JSON.stringify(macrodlg_macrolist, null, " ")], {
-		type: "application/json",
-	});
+	const blob = new Blob([JSON.stringify(macrodlg_macrolist, null, " ")], { type: "application/json" });
 	let file;
 	if (browser_is("IE") || browser_is("Edge")) {
 		file = blob;
 		file.name = "/macrocfg.json";
 		file.lastModifiedDate = new Date();
-	} else file = new File([blob], "/macrocfg.json");
+	} else {
+		file = new File([blob], "/macrocfg.json");
+	}
+
 	const formData = new FormData();
-	const url = "/files";
 	formData.append("path", "/");
 	formData.append("myfile[]", file, "/macrocfg.json");
 	SendFileHttp(
-		url,
+		httpCmd.files,
 		formData,
 		macrodlgUploadProgressDisplay,
 		macroUploadsuccess,

--- a/www/js/macrodlg.js
+++ b/www/js/macrodlg.js
@@ -303,24 +303,19 @@ function SaveNewMacroList() {
 
 	const blob = new Blob([JSON.stringify(macrodlg_macrolist, null, " ")], { type: "application/json" });
 	let file;
+	const macroFilename = "/macrocfg.json";
 	if (browser_is("IE") || browser_is("Edge")) {
 		file = blob;
-		file.name = "/macrocfg.json";
+		file.name = macroFilename;
 		file.lastModifiedDate = new Date();
 	} else {
-		file = new File([blob], "/macrocfg.json");
+		file = new File([blob], macroFilename);
 	}
 
 	const formData = new FormData();
 	formData.append("path", "/");
-	formData.append("myfile[]", file, "/macrocfg.json");
-	SendFileHttp(
-		httpCmd.files,
-		formData,
-		macrodlgUploadProgressDisplay,
-		macroUploadsuccess,
-		macroUploadfailed,
-	);
+	formData.append("myfile[]", file, macroFilename);
+	SendFileHttp(httpCmd.files, formData, macrodlgUploadProgressDisplay, macroUploadsuccess, macroUploadfailed);
 }
 
 function macrodlgUploadProgressDisplay(oEvent) {

--- a/www/js/macrodlg.js
+++ b/www/js/macrodlg.js
@@ -9,10 +9,10 @@ function showmacrodlg(closefn) {
 		return;
 	}
 
-	id("macrodlg.html").addEventListener("click", (event) => clear_drop_menu(event));
-	id("MacroDialogClose").addEventListener("click", (event) => closeMacroDialog());
-	id("MacroDialogCancel").addEventListener("click", (event) => closeMacroDialog());
-	id("MacroDialogSave").addEventListener("click", (event) => SaveNewMacroList());
+	id("macrodlg.html").addEventListener("click", clear_drop_menu);
+	id("MacroDialogClose").addEventListener("click", closeMacroDialog);
+	id("MacroDialogCancel").addEventListener("click", closeMacroDialog);
+	id("MacroDialogSave").addEventListener("click", SaveNewMacroList);
 
 	build_dlg_macrolist_ui();
 	displayNone("macrodlg_upload_msg");
@@ -33,7 +33,7 @@ function build_color_selection(index, actions) {
 	content += "</g>";
 	content += "</svg>";
 	content += "</button>";
-	actions.push({ id: `macro_color_line${index}_btn`, type: "click", method: (event) => showhide_drop_menu(event) });
+	actions.push({ id: `macro_color_line${index}_btn`, type: "click", method: showhide_drop_menu });
 	content += `<div class='dropmenu-content ${menu_pos}' style='min-width:auto; padding-left: 4px;padding-right: 4px;'>`;
 	for ((col) in ["default", "primary", "info", "warning", "danger"]) {
 		content += `<button id='macro_select_color_${col}${index}_btn' class='btn btn-${col}'>&nbsp;</button>`;
@@ -58,7 +58,7 @@ function build_target_selection(index, actions) {
 	content += "</g>";
 	content += "</svg>";
 	content += "</button>";
-	actions.push({ id: `macro_target_line${index}_btn`, type: "click", method: (event) => showhide_drop_menu(event) });
+	actions.push({ id: `macro_target_line${index}_btn`, type: "click", method: showhide_drop_menu });
 	content += `<div class='dropmenu-content ${menu_pos}' style='min-width:auto'>`;
 	content += `<a id='macro_select_targetESP${index}_link' href=#>ESP</a>`;
 	content += `<a id='macro_select_targetSD${index}_link' href=#>SD</a>`;
@@ -86,7 +86,7 @@ function build_glyph_selection(index, actions) {
 	content += "</g>";
 	content += "</svg>";
 	content += "</button>";
-	actions.push({ id: `macro_glyph_line${index}_btn`, type: "click", method: (event) => showhide_drop_menu(event) });
+	actions.push({ id: `macro_glyph_line${index}_btn`, type: "click", method: showhide_drop_menu });
 	content += `<div class='dropmenu-content ${menu_pos}' style='min-width:30em'>`;
 	for (const key in list_icon) {
 		if (key === "plus") {
@@ -149,7 +149,10 @@ function build_dlg_macrolist_line(index) {
 
 	setHTML(`macro_line_${index}`, content);
 	actions.forEach((action) => {
-		id(action.id).addEventListener(action.type, action.method);
+		const elem = id(action.id);
+		if (elem) {
+			elem.addEventListener(action.type, action.method);
+		}
 	});
 }
 
@@ -174,10 +177,7 @@ function on_macro_filename(event, index) {
 	const filename = event.value.trim();
 	entry.filename = event.value;
 	if (filename.length === 0) {
-		alertdlg(
-			translate_text_item("Out of range"),
-			translate_text_item("File name cannot be empty!"),
-		);
+		alertdlg(translate_text_item("Out of range"), translate_text_item("File name cannot be empty!"));
 	}
 	build_dlg_macrolist_line(index);
 }

--- a/www/js/modaldlg.js
+++ b/www/js/modaldlg.js
@@ -11,8 +11,7 @@ function setactiveModal(html_template, closefunc) {
     modal.element = id(html_template);
     modal.id = listmodal.length;
     modal.name = html_template;
-    if (typeof closefunc !== 'undefined') modal.closefn = closefunc;
-    else modal.closefn = myfnclose;
+    modal.closefn = (typeof closefunc === "function") ? closefunc : myfnclose;
     listmodal.push(modal)
     //console.log("Creation of modal  " +  modal.name + " with ID " +modal.id);
     return listmodal[listmodal.length - 1];;
@@ -34,7 +33,7 @@ function showModal() {
 // When the user clicks on <span> (x), close the modal
 function closeModal(response) {
     var currentmodal = getactiveModal();
-    if (currentmodal != null) {
+    if (currentmodal !== null) {
         currentmodal.element.style.display = "none";
         var closefn = currentmodal.closefn;
         //console.log("Deletetion of modal " +  currentmodal.name + " with ID "  + currentmodal.id);
@@ -48,5 +47,5 @@ function closeModal(response) {
 }
 //default close function
 function myfnclose(value) {
-    //console.log("modale closed: " + value);
+    //console.log("modal closed: " + value);
 }

--- a/www/js/navbar.js
+++ b/www/js/navbar.js
@@ -1,23 +1,31 @@
 // import - disable_items, displayNone, getChecked, id, setChecked, setHTML, opentab, creditsdlg, cameratab, configtab, changepassworddlg, showpreferencesdlg, translate_text_item, DisconnectLogin, setupdlg, settingstab
 
+const navBarMainTabLink = (event) => opentab(event, "maintab", "mainuitabscontent", "mainuitablinks");
+const navBarCamTabLink = (event) => opentab(event, "cameratab", "mainuitabscontent", "mainuitablinks");
+const navBarConfigTabLink = (event) => opentab(event, "configtab", "mainuitabscontent", "mainuitablinks");
+const navBarSettingTabLink = (event) => opentab(event, "settingstab", "mainuitabscontent", "mainuitablinks");
+const navBarTabletTabLink = (event) => opentab(event, "tablettab", "mainuitabscontent", "mainuitablinks");
+
+const navBarLogout = () => confirmdlg(translate_text_item("Disconnection requested"), translate_text_item("Please confirm disconnection."), DisconnectLogin);
+
 /** Set up the event handlers for the navbar */
 const navbar = () => {
-	id("toggleLockUI").addEventListener("click", (event) => ontoggleLock());
+	id("toggleLockUI").addEventListener("click", ontoggleLock);
 
-	id("showPreferencesDlg").addEventListener("click", (event) => showpreferencesdlg());
-	id("showSetupDlg").addEventListener("click", (event) => setupdlg());
-	id("showCreditsDlg").addEventListener("click", (event) => creditsdlg());
+	id("showPreferencesDlg").addEventListener("click", showpreferencesdlg);
+	id("showSetupDlg").addEventListener("click", setupdlg);
+	id("showCreditsDlg").addEventListener("click", creditsdlg);
 
 	// Note: for `maintab` see dashtab.html
-	id("maintablink").addEventListener("click", (event) => opentab(event, "maintab", "mainuitabscontent", "mainuitablinks"));
-	id("camtablink").addEventListener("click", (event) => opentab(event, "cameratab", "mainuitabscontent", "mainuitablinks"));
-	id("configtablink").addEventListener("click", (event) => opentab(event, "configtab", "mainuitabscontent", "mainuitablinks"));
-	id("settingtablink").addEventListener("click", (event) => opentab(event, "settingstab", "mainuitabscontent", "mainuitablinks"));
-	id("tablettablink").addEventListener("click", (event) => opentab(event, "tablettab", "mainuitabscontent", "mainuitablinks"));
+	id("maintablink").addEventListener("click", navBarMainTabLink);
+	id("camtablink").addEventListener("click", navBarCamTabLink);
+	id("configtablink").addEventListener("click", navBarConfigTabLink);
+	id("settingtablink").addEventListener("click", navBarSettingTabLink);
+	id("tablettablink").addEventListener("click", navBarTabletTabLink);
 
-	id("password_menu").addEventListener("click", (event) => changepassworddlg());
-	id("showLoginDlg").addEventListener("click", (event) => logindlg());
-	id("logout_menu").addEventListener("click", (event) => confirmdlg(translate_text_item("Disconnection requested"), translate_text_item("Please confirm disconnection."), DisconnectLogin,));
+	id("password_menu").addEventListener("click", changepassworddlg);
+	id("showLoginDlg").addEventListener("click", logindlg);
+	id("logout_menu").addEventListener("click", navBarLogout);
 
 	cameratab();
 	configtab();

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -65,7 +65,7 @@ function SubmitChangePassword() {
 	const user = id("current_ID").innerHTML.trim();
 	const password = id("password_password_text").value.trim();
 	const newpassword = id("password_password_text1").value.trim();
-	
-	const cmd = buildHttpLoginCmd({"USER": user, "PASSWORD": password, "NEWPASSWORD": newpassword});
+
+	const cmd = buildHttpLoginCmd({ USER: user, PASSWORD: password, NEWPASSWORD: newpassword });
 	SendGetHttp(cmd, ChangePasswordsuccess, ChangePasswordfailed);
 }

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -62,8 +62,8 @@ function SubmitChangePassword() {
 	const user = encodeURIComponent(id("current_ID").innerHTML.trim());
 	const password = encodeURIComponent(id("password_password_text").value.trim());
 	const newpassword = encodeURIComponent(id("password_password_text1").value.trim());
-	const url = `/login?USER=${user}&PASSWORD=${password}&NEWPASSWORD=${newpassword}&SUBMIT=yes`;
+	const cmd = `${httpCmd.login}?USER=${user}&PASSWORD=${password}&NEWPASSWORD=${newpassword}&SUBMIT=yes`;
 	displayBlock("password_loader");
 	displayNone("change_password_content");
-	SendGetHttp(url, ChangePasswordsuccess, ChangePasswordfailed);
+	SendGetHttp(cmd, ChangePasswordsuccess, ChangePasswordfailed);
 }

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -59,11 +59,13 @@ function ChangePasswordsuccess(response_text) {
 }
 
 function SubmitChangePassword() {
-	const user = encodeURIComponent(id("current_ID").innerHTML.trim());
-	const password = encodeURIComponent(id("password_password_text").value.trim());
-	const newpassword = encodeURIComponent(id("password_password_text1").value.trim());
-	const cmd = `${httpCmd.login}?USER=${user}&PASSWORD=${password}&NEWPASSWORD=${newpassword}&SUBMIT=yes`;
 	displayBlock("password_loader");
 	displayNone("change_password_content");
+
+	const user = id("current_ID").innerHTML.trim();
+	const password = id("password_password_text").value.trim();
+	const newpassword = id("password_password_text1").value.trim();
+	
+	const cmd = buildHttpLoginCmd({"USER": user, "PASSWORD": password, "NEWPASSWORD": newpassword});
 	SendGetHttp(cmd, ChangePasswordsuccess, ChangePasswordfailed);
 }

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -1,5 +1,7 @@
 // import conErr, displayBlock, displayNone, id, setHTML, closeModal, setactiveModal, showModal, SendGetHttp, translate_text_item 
 
+const passwordDlgCancel = () => closeModal("cancel");
+
 /** Change Password dialog */
 const changepassworddlg = () => {
 	const modal = setactiveModal("passworddlg.html");
@@ -7,11 +9,11 @@ const changepassworddlg = () => {
 		return;
 	}
 
-	id("passwordDlgClose").addEventListener("click", (event) => closeModal("cancel"));
-	id("password_password_text1").addEventListener("keyup", (event) => checkpassword());
-	id("password_password_text2").addEventListener("keyup", (event) => checkpassword());
-	id("passwordDlgCancel").addEventListener("click", (event) => closeModal("cancel"));
-	id("change_password_btn").addEventListener("click", (event) => SubmitChangePassword());
+	id("passwordDlgClose").addEventListener("click", passwordDlgCancel);
+	id("password_password_text1").addEventListener("keyup", checkpassword);
+	id("password_password_text2").addEventListener("keyup", checkpassword);
+	id("passwordDlgCancel").addEventListener("click", passwordDlgCancel);
+	id("change_password_btn").addEventListener("click", SubmitChangePassword);
 
 	displayNone("password_loader");
 	displayBlock("change_password_content");

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -626,13 +626,18 @@ function SavePreferences(current_preferences) {
         file = blob;
         file.name = preferences_file_name;
         file.lastModifiedDate = new Date();
-    } else file = new File([blob], preferences_file_name);
+    } else {
+        file = new File([blob], preferences_file_name);
+    }
+
     var formData = new FormData();
-    var url = "/files";
     formData.append('path', '/');
     formData.append('myfile[]', file, preferences_file_name);
-    if ((typeof (current_preferences) != 'undefined') && current_preferences) SendFileHttp(url, formData);
-    else SendFileHttp(url, formData, preferencesdlgUploadProgressDisplay, preferencesUploadsuccess, preferencesUploadfailed);
+    if ((typeof (current_preferences) != 'undefined') && current_preferences) {
+        SendFileHttp(httpCmd.files, formData);
+    } else {
+        SendFileHttp(httpCmd.files, formData, preferencesdlgUploadProgressDisplay, preferencesUploadsuccess, preferencesUploadfailed);
+    }
 }
 
 function preferencesdlgUploadProgressDisplay(oEvent) {

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -3,41 +3,41 @@ var preferenceslist = [];
 var language_save = language;
 var default_preferenceslist = [];
 var defaultpreferenceslist = "[{\
-                                            \"language\":\"en\",\
-                                            \"enable_lock_UI\":\"false\",\
-                                            \"enable_ping\":\"true\",\
-                                            \"enable_DHT\":\"false\",\
-                                            \"enable_camera\":\"false\",\
-                                            \"auto_load_camera\":\"false\",\
-                                            \"camera_address\":\"\",\
-                                            \"enable_redundant\":\"false\",\
-                                            \"enable_probe\":\"false\",\
-                                            \"enable_control_panel\":\"true\",\
-                                            \"enable_grbl_panel\":\"true\",\
-                                            \"autoreport_interval\":\"50\",\
-                                            \"interval_positions\":\"3\",\
-                                            \"interval_status\":\"3\",\
-                                            \"xy_feedrate\":\"2500\",\
-                                            \"z_feedrate\":\"300\",\
-                                            \"a_feedrate\":\"100\",\
-                                            \"b_feedrate\":\"100\",\
-                                            \"c_feedrate\":\"100\",\
-                                            \"e_feedrate\":\"400\",\
-                                            \"e_distance\":\"5\",\
-                                            \"f_filters\":\"g;gc;gco;gcode;nc;txt;G;GC;GCO;GCODE;NC;TXT\",\
-                                            \"enable_files_panel\":\"true\",\
-                                            \"has_TFT_SD\":\"false\",\
-                                            \"has_TFT_USB\":\"false\",\
-                                            \"enable_commands_panel\":\"true\",\
-                                            \"enable_autoscroll\":\"true\",\
-                                            \"enable_verbose_mode\":\"true\",\
-                                            \"enable_grbl_probe_panel\":\"false\",\
-                                            \"probemaxtravel\":\"40\",\
-                                            \"probefeedrate\":\"100\",\
-                                            \"proberetract\":\"1.0\",\
-                                            \"probetouchplatethickness\":\"0.5\"\
-                                            }]";
-var preferences_file_name = '/preferences.json';
+    \"language\":\"en\",\
+    \"enable_lock_UI\":\"false\",\
+    \"enable_ping\":\"true\",\
+    \"enable_DHT\":\"false\",\
+    \"enable_camera\":\"false\",\
+    \"auto_load_camera\":\"false\",\
+    \"camera_address\":\"\",\
+    \"enable_redundant\":\"false\",\
+    \"enable_probe\":\"false\",\
+    \"enable_control_panel\":\"true\",\
+    \"enable_grbl_panel\":\"true\",\
+    \"autoreport_interval\":\"50\",\
+    \"interval_positions\":\"3\",\
+    \"interval_status\":\"3\",\
+    \"xy_feedrate\":\"2500\",\
+    \"z_feedrate\":\"300\",\
+    \"a_feedrate\":\"100\",\
+    \"b_feedrate\":\"100\",\
+    \"c_feedrate\":\"100\",\
+    \"e_feedrate\":\"400\",\
+    \"e_distance\":\"5\",\
+    \"f_filters\":\"g;gc;gco;gcode;nc;txt;G;GC;GCO;GCODE;NC;TXT\",\
+    \"enable_files_panel\":\"true\",\
+    \"has_TFT_SD\":\"false\",\
+    \"has_TFT_USB\":\"false\",\
+    \"enable_commands_panel\":\"true\",\
+    \"enable_autoscroll\":\"true\",\
+    \"enable_verbose_mode\":\"true\",\
+    \"enable_grbl_probe_panel\":\"false\",\
+    \"probemaxtravel\":\"40\",\
+    \"probefeedrate\":\"100\",\
+    \"proberetract\":\"1.0\",\
+    \"probetouchplatethickness\":\"0.5\"\
+    }]";
+const preferences_file_name = "preferences.json";
 
 function initpreferences() {
     displayNone('DHT_pref_panel');
@@ -49,14 +49,14 @@ function initpreferences() {
 }
 
 function getpreferenceslist() {
-    var url = preferences_file_name;
     preferenceslist = [];
     //removeIf(production)
     var response = defaultpreferenceslist;
     processPreferencesGetSuccess(response);
     return;
     //endRemoveIf(production)
-    SendGetHttp(url, processPreferencesGetSuccess, processPreferencesGetFailed);
+    const cmd = buildHttpFileGetCmd(preferences_file_name);
+    SendGetHttp(cmd, processPreferencesGetSuccess, processPreferencesGetFailed);
 }
 
 function prefs_toggledisplay(id_source, forcevalue) {
@@ -622,17 +622,18 @@ function SavePreferences(current_preferences) {
     }
     const blob = new Blob([JSON.stringify(preferenceslist, null, " ")], { type: 'application/json' });
     var file;
+    const prefsFilePath = `/${preferences_file_name}`;
     if (browser_is("IE") || browser_is("Edge")) {
         file = blob;
-        file.name = preferences_file_name;
+        file.name = prefsFilePath;
         file.lastModifiedDate = new Date();
     } else {
-        file = new File([blob], preferences_file_name);
+        file = new File([blob], prefsFilePath);
     }
 
     var formData = new FormData();
     formData.append('path', '/');
-    formData.append('myfile[]', file, preferences_file_name);
+    formData.append('myfile[]', file, prefsFilePath);
     if ((typeof (current_preferences) != 'undefined') && current_preferences) {
         SendFileHttp(httpCmd.files, formData);
     } else {

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -13,7 +13,7 @@ var defaultpreferenceslist = "[{\
                                             \"enable_redundant\":\"false\",\
                                             \"enable_probe\":\"false\",\
                                             \"enable_control_panel\":\"true\",\
-                                            \"enable_grbl_panel\":\"false\",\
+                                            \"enable_grbl_panel\":\"true\",\
                                             \"autoreport_interval\":\"50\",\
                                             \"interval_positions\":\"3\",\
                                             \"interval_status\":\"3\",\

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -24,7 +24,7 @@ var defaultpreferenceslist = "[{\
                                             \"c_feedrate\":\"100\",\
                                             \"e_feedrate\":\"400\",\
                                             \"e_distance\":\"5\",\
-                                            \"f_filters\":\".g;.gc;.gco;.gcode;.nc;.txt;.G;.GC;.GCO;.GCODE;.NC;.TXT\",\
+                                            \"f_filters\":\"g;gc;gco;gcode;nc;txt;G;GC;GCO;GCODE;NC;TXT\",\
                                             \"enable_files_panel\":\"true\",\
                                             \"has_TFT_SD\":\"false\",\
                                             \"has_TFT_USB\":\"false\",\

--- a/www/js/printercmd.js
+++ b/www/js/printercmd.js
@@ -2,7 +2,7 @@ var grbl_processfn = null;
 var grbl_errorfn = null;
 
 function noop() {}
-function SendPrinterCommand(prnCmd, echo_on, processfn, errorfn, id, max_id, extra_arg) {
+function SendPrinterCommand(prnCmd, echo_on, processfn, errorfn, cmd_code, max_cmd_code, extra_arg) {
     if (prnCmd.trim().length === 0) {
         return;
     }
@@ -37,7 +37,7 @@ function SendPrinterCommand(prnCmd, echo_on, processfn, errorfn, id, max_id, ext
         cmd += `&${extra_arg}`;
     }
 
-    SendGetHttp(cmd, procFn, errFn, id, max_id);
+    SendGetHttp(cmd, procFn, errFn, cmd_code, max_cmd_code);
     //console.log(cmd);
 }
 

--- a/www/js/printercmd.js
+++ b/www/js/printercmd.js
@@ -32,7 +32,7 @@ function SendPrinterCommand(prnCmd, echo_on, processfn, errorfn, id, max_id, ext
         errFn = noop;
     }
 
-	let cmd = buildHttpCommandCmd(prnCmd);
+	let cmd = buildHttpCommandCmd(httpCmdType.commandText, prnCmd);
     if (extra_arg) {
         cmd += `&${extra_arg}`;
     }

--- a/www/js/printercmd.js
+++ b/www/js/printercmd.js
@@ -2,56 +2,43 @@ var grbl_processfn = null;
 var grbl_errorfn = null;
 
 function noop() {}
-function SendPrinterCommand(cmd, echo_on, processfn, errorfn, id, max_id, extra_arg) {
-    var url = "/command?commandText=";
-    var push_cmd = true;
-    if (typeof echo_on !== 'undefined') {
-        push_cmd = echo_on;
+function SendPrinterCommand(prnCmd, echo_on, processfn, errorfn, id, max_id, extra_arg) {
+    if (prnCmd.trim().length === 0) {
+        return;
     }
-    if (cmd.length == 0) return;
-    if (push_cmd) Monitor_output_Update("[#]" + cmd + "\n");
+
+    var push_cmd = typeof echo_on !== 'undefined' ? echo_on : true;
+    if (push_cmd) {
+        Monitor_output_Update(`[#]${prnCmd.trim()}\n`);
+    }
+
     //removeIf(production)
-    console.log(cmd);
-    if (typeof processfn !== 'undefined') processfn("Test response");
-    else SendPrinterCommandSuccess("Test response");
+    console.log(prnCmd);
+    if (typeof processfn !== 'undefined') {
+        processfn("Test response");
+    } else {
+        SendPrinterCommandSuccess("Test response");
+    }
     return;
     //endRemoveIf(production)
-    if (typeof processfn === 'undefined' || processfn == null) processfn = SendPrinterCommandSuccess;
-    if (typeof errorfn === 'undefined' || errorfn == null) errorfn = SendPrinterCommandFailed;
-    if (!cmd.startsWith("[ESP")) {
-        grbl_processfn = processfn;
-        grbl_errorfn = errorfn;
-        processfn = noop;
-        errorfn = noop;
+
+    // Ensure that we have valid functions defined for process and error returns
+    let procFn = typeof processfn === "function" ? processfn : SendPrinterCommandSuccess;
+    let errFn = typeof errorfn === "function" ? errorfn : SendPrinterCommandFailed;
+    if (!prnCmd.startsWith("[ESP")) {
+        grbl_processfn = procFn;
+        grbl_errorfn = errFn;
+        procFn = noop;
+        errFn = noop;
     }
-    cmd = encodeURI(cmd);
-    cmd = cmd.replace("#", "%23");
+
+	let cmd = buildHttpCommandCmd(prnCmd);
     if (extra_arg) {
-        cmd += "&" + extra_arg;
+        cmd += `&${extra_arg}`;
     }
-    SendGetHttp(url + cmd, processfn, errorfn, id, max_id);
-    //console.log(cmd);
-}
 
-function SendPrinterSilentCommand(cmd, processfn, errorfn, id, max_id) {
-    var url = "/command_silent?commandText=";
-    if (cmd.length == 0) return;
-    //removeIf(production)
-    console.log(cmd);
-    if (typeof processfn !== 'undefined') processfn("Test response");
-    else SendPrinterCommandSuccess("Test response");
-    return;
-    //endRemoveIf(production)
-    if (typeof processfn === 'undefined' || processfn == null) processfn = SendPrinterSilentCommandSuccess;
-    if (typeof errorfn === 'undefined' || errorfn == null) errorfn = SendPrinterCommandFailed;
-    cmd = encodeURI(cmd);
-    cmd = cmd.replace("#", "%23");
-    SendGetHttp(url + cmd, processfn, errorfn, id, max_id);
+    SendGetHttp(cmd, procFn, errFn, id, max_id);
     //console.log(cmd);
-}
-
-function SendPrinterSilentCommandSuccess(response) {
-    //console.log(response);
 }
 
 function SendPrinterCommandSuccess(response) {
@@ -61,6 +48,7 @@ function SendPrinterCommandFailed(error_code, response) {
     const errMsg = (error_code === 0)
         ? translate_text_item("Connection error")
         : stdErrMsg(error_code, HTMLDecode(response), translate_text_item("Error"));
+
     Monitor_output_Update(`${errMsg}\n`);
 
     conErr(error_code, HTMLDecode(response), "printer cmd Error");

--- a/www/js/scanwifidlg.js
+++ b/www/js/scanwifidlg.js
@@ -46,8 +46,8 @@ function refresh_scanwifi() {
 	getscanWifiSuccess(testResponse.join(""));
 	return;
 	//endRemoveIf(production)
-	const url = `/command?plain=${encodeURIComponent("[ESP410]")}`;
-	SendGetHttp(url, getscanWifiSuccess, getscanWififailed);
+	const cmd = buildHttpPlainCmd("[ESP410]");
+	SendGetHttp(cmd, getscanWifiSuccess, getscanWififailed);
 }
 
 function process_scanWifi_answer(response_text) {

--- a/www/js/scanwifidlg.js
+++ b/www/js/scanwifidlg.js
@@ -46,7 +46,7 @@ function refresh_scanwifi() {
 	getscanWifiSuccess(testResponse.join(""));
 	return;
 	//endRemoveIf(production)
-	const cmd = buildHttpPlainCmd("[ESP410]");
+	const cmd = buildHttpCommandCmd(httpCmdType.plain, "[ESP410]");
 	SendGetHttp(cmd, getscanWifiSuccess, getscanWififailed);
 }
 

--- a/www/js/scanwifidlg.js
+++ b/www/js/scanwifidlg.js
@@ -3,6 +3,8 @@
 let ssid_item_scanwifi = -1;
 let ssid_subitem_scanwifi = -1;
 
+const scanWiFiDlgCancel = () => closeModal("cancel");
+
 /** scanwifi dialog */
 const scanwifidlg = (item, subitem) => {
 	const modal = setactiveModal("scanwifidlg.html", scanwifidlg_close);
@@ -10,9 +12,9 @@ const scanwifidlg = (item, subitem) => {
 		return;
 	}
 
-	id("scanWiFiDlgCancel").addEventListener("click", (event) => closeModal("cancel"));
-	id("scanWiFiDlgClose").addEventListener("click", (event) => closeModal("cancel"));
-	id("refresh_scanwifi_btn").addEventListener("click", (event) => refresh_scanwifi());
+	id("scanWiFiDlgCancel").addEventListener("click", scanWiFiDlgCancel);
+	id("scanWiFiDlgClose").addEventListener("click", scanWiFiDlgCancel);
+	id("refresh_scanwifi_btn").addEventListener("click", refresh_scanwifi);
 
 	ssid_item_scanwifi = item;
 	ssid_subitem_scanwifi = subitem;
@@ -62,8 +64,8 @@ function process_scanWifi_answer(response_text) {
 			const aplist = response.AP_LIST;
 			//console.log("found " + aplist.length + " AP");
 			aplist.sort((a, b) => Number.parseInt(a.SIGNAL) < Number.parseInt(b.SIGNAL)
-					? -1
-					: Number.parseInt(a.SIGNAL) > Number.parseInt(b.SIGNAL) ? 1 : 0);
+				? -1
+				: Number.parseInt(a.SIGNAL) > Number.parseInt(b.SIGNAL) ? 1 : 0);
 			for (let i = aplist.length - 1; i >= 0; i--) {
 				const protIcon = aplist[i].IS_PROTECTED === "1" ? get_icon_svg("lock") : "";
 				const escapedSSID = aplist[i].SSID.replace("'", "\\'").replace('"', '\\"',);
@@ -74,7 +76,7 @@ function process_scanWifi_answer(response_text) {
 				content += `<td style='text-align:center;vertical-align:middle'>${protIcon}</td>`;
 				content += `<td><button id="${btnId}" class='btn btn-primary'>${get_icon_svg("ok")}</button></td>`;
 				content += "</tr>";
-				actions.push({ id: btnId, type: "click", method:select_ap_ssid, index:escapedSSID });
+				actions.push({ id: btnId, type: "click", method: select_ap_ssid, index: escapedSSID });
 			}
 		}
 	} catch (e) {
@@ -84,7 +86,10 @@ function process_scanWifi_answer(response_text) {
 	setHTML("AP_scan_data", content);
 
 	actions.forEach((action) => {
-		id(action.id).addEventListener("click", (event) => action.method(action.index));
+		const elem = id(action.id);
+		if (elem) {
+			elem.addEventListener("click", (event) => action.method(action.index));
+		}
 	});
 
 	return result;

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -34,19 +34,19 @@ const CONFIG_TOOLTIPS = {
 
 function refreshSettings(hide_setting_list) {
   if (http_communication_locked) {
-    id('config_status').innerHTML = translate_text_item('Communication locked by another process, retry later.')
-    return
+    id('config_status').innerHTML = translate_text_item('Communication locked by another process, retry later.');
+    return;
   }
-  do_not_build_settings = typeof hide_setting_list == 'undefined' ? false : !hide_setting_list
+  do_not_build_settings = typeof hide_setting_list === 'undefined' ? false : !hide_setting_list;
 
-  displayBlock('settings_loader')
-  displayNone('settings_list_content')
-  displayNone('settings_status')
-  displayNone('settings_refresh_btn')
+  displayBlock('settings_loader');
+  displayNone('settings_list_content');
+  displayNone('settings_status');
+  displayNone('settings_refresh_btn');
 
-  scl = []
-  var url = '/command?plain=' + encodeURIComponent('[ESP400]')
-  SendGetHttp(url, getESPsettingsSuccess, getESPsettingsfailed)
+  scl = [];
+  const cmd = buildHttpPlainCmd("[ESP400]");
+  SendGetHttp(cmd, getESPsettingsSuccess, getESPsettingsfailed);
 }
 
 function defval(i) {
@@ -196,7 +196,8 @@ function build_control_from_pos(pos, extra) {
  * @see maslow.js maslowErrorMsgHandling()
  */
 function saveMaslowYaml() {
-  SendGetHttp('/command?plain=' + encodeURIComponent("$CO"));
+  const cmd = buildHttpPlainCmd("$CO");
+  SendGetHttp(cmd);
 }
 
 function build_HTML_setting_list(filter) {
@@ -436,39 +437,43 @@ function setting_revert_to_default(i, j) {
   setIconHTML(i, j, '');
 }
 
-function settingsetvalue(i, j) {
-  if (typeof j == 'undefined') j = 0
+function settingsetvalue(i, j = 0) {
   //remove possible spaces
-  value = setting(i, j).value.trim()
+  let value = setting(i, j).value.trim();
+
   //Apply flag here
-  if (scl[i].type == 'F') {
-    var tmp = defval(i)
-    if (value == '1') {
-      tmp |= getFlag(i, j)
+  if (scl[i].type === 'F') {
+    var tmp = defval(i);
+    if (value === '1') {
+      tmp |= getFlag(i, j);
     } else {
-      tmp &= ~getFlag(i, j)
+      tmp &= ~getFlag(i, j);
     }
-    value = tmp
+    value = tmp;
   }
-  if (value == defval(i)) return
+  if (value == defval(i)) {
+    return;
+  }
+
   //check validity of value
-  var isvalid = setting_check_value(value, i)
+  var isvalid = setting_check_value(value, i);
+
   //if not valid show error
   if (!isvalid) {
     setsettingerror(i)
-    alertdlg(translate_text_item('Out of range'), translate_text_item('Value must be ') + setting_error_msg + ' !')
+    alertdlg(translate_text_item('Out of range'), `${translate_text_item('Value must be ')}${setting_error_msg}!`);
   } else {
     //value is ok save it
-    var cmd = scl[i].cmd + value
-    setting_lasti = i
-    setting_lastj = j
-    scl[i].defaultvalue = value
-    setBtn(i, j, 'btn-success')
-    setIcon(i, j, 'has-success ico_feedback')
-    setIconHTML(i, j, get_icon_svg('ok'))
-    setStatus(i, j, 'has-feedback has-success')
-    var url = '/command?plain=' + encodeURIComponent(cmd)
-    SendGetHttp(url, setESPsettingsSuccess, setESPsettingsfailed)
+    setting_lasti = i;
+    setting_lastj = j;
+    scl[i].defaultvalue = value;
+    setBtn(i, j, 'btn-success');
+    setIcon(i, j, 'has-success ico_feedback');
+    setIconHTML(i, j, get_icon_svg('ok'));
+    setStatus(i, j, 'has-feedback has-success');
+
+    const cmd = buildHttpPlainCmd(`${scl[i].cmd}${value}`);
+    SendGetHttp(cmd, setESPsettingsSuccess, setESPsettingsfailed);
   }
 }
 

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -226,16 +226,16 @@ const saveMaslowYaml = () => {
 	SendGetHttp(`/command?plain=${encodeURIComponent("$CO")}`, saveConfigSuccess, saveConfigFail);
 }
 
-const saveConfigClearMessage = () =>  setTimeout(() => {setHTML(configSaveResultId, "");}, 5000)
+const saveConfigClearMessage = () => setTimeout(() => { setHTML(configSaveResultId, ""); }, 5000)
 
 const saveConfigSuccess = (response) => {
 	setHTML(configSaveResultId, `"Save" ${configFileName} succeeded`);
-    saveConfigClearMessage();
+	saveConfigClearMessage();
 }
 
 const saveConfigFail = (response) => {
 	setHTML(configSaveResultId, `"Save" ${configFileName} failed`);
-    saveConfigClearMessage();
+	saveConfigClearMessage();
 }
 
 /** Build the HTML for the list of settings */

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -50,7 +50,7 @@ const refreshSettings = (hide_setting_list) => {
 
   // Clear all of the elements in the array
   scl.length = 0;
-  const cmd = buildHttpPlainCmd("[ESP400]");
+  const cmd = buildHttpCommandCmd(httpCmdType.plain, "[ESP400]");
   SendGetHttp(cmd, getESPsettingsSuccess, getESPsettingsfailed);
 };
 
@@ -223,7 +223,7 @@ const build_control_from_pos = (pos, actions, extra) => build_control_from_index
  */
 const saveMaslowYaml = () => {
   console.info(`Calling for a Config Overwrite to save the ${configFileName} file`);
-  const cmd = buildHttpPlainCmd("$CO");
+  const cmd = buildHttpCommandCmd(httpCmdType.plain, "$CO");
   SendGetHttp(cmd, saveConfigSuccess, saveConfigFail);
 }
 
@@ -552,7 +552,7 @@ function settingsetvalue(i, j = 0) {
     setIconHTML(i, j, get_icon_svg("ok"));
     setStatus(i, j, "has-feedback has-success");
 
-    const cmd = buildHttpPlainCmd(`${scl[i].cmd}${value}`);
+    const cmd = buildHttpCommandCmd(httpCmdType.plain, `${scl[i].cmd}${value}`);
     SendGetHttp(cmd, setESPsettingsSuccess, setESPsettingsfailed);
   }
 }

--- a/www/js/socket.js
+++ b/www/js/socket.js
@@ -44,7 +44,9 @@ const Disable_interface = (lostconnection) => {
 	//block all communication
 	http_communication_locked = true;
 	log_off = true;
-	if (interval_ping !== -1) clearInterval(interval_ping);
+	if (interval_ping !== -1) {
+		clearInterval(interval_ping);
+	}
 	//clear all waiting commands
 	clear_cmd_list();
 	//no camera

--- a/www/js/statusdlg.js
+++ b/www/js/statusdlg.js
@@ -99,6 +99,6 @@ function refreshstatus() {
 	text.innerHTML = "";
 	displayNone("status_msg");
 
-	const cmd = buildHttpPlainCmd("[ESP420]plain");
+	const cmd = buildHttpCommandCmd(httpCmdType.plain, "[ESP420]plain");
 	SendGetHttp(cmd, statussuccess, statusfailed);
 }

--- a/www/js/statusdlg.js
+++ b/www/js/statusdlg.js
@@ -2,17 +2,20 @@
 
 let statuspage = 0;
 let statuscontent = "";
-//status dialog
+
+const statusDlgCancel = () => closeModal("cancel");
+
+/** status dialog */
 const statusdlg = () => {
 	const modal = setactiveModal("statusdlg.html");
 	if (modal == null) {
 		return;
 	}
 
-	id("status_dlg_close").addEventListener("click", (event) => closeModal("cancel"));
-	id("next_status_btn").addEventListener("click", (event) => next_status());
-	id("status_dlg_btn_close").addEventListener("click", (event) => closeModal("cancel"));
-	id("status_dlg_refreshstatus").addEventListener("click", (event) => refreshstatus());
+	id("status_dlg_close").addEventListener("click", statusDlgCancel);
+	id("next_status_btn").addEventListener("click", next_status);
+	id("status_dlg_btn_close").addEventListener("click", statusDlgCancel);
+	id("status_dlg_refreshstatus").addEventListener("click", refreshstatus);
 
 	showModal();
 	refreshstatus();

--- a/www/js/statusdlg.js
+++ b/www/js/statusdlg.js
@@ -98,6 +98,7 @@ function refreshstatus() {
 	const text = modal.element.getElementsByClassName("modal-text")[0];
 	text.innerHTML = "";
 	displayNone("status_msg");
-	const url = `/command?plain=${encodeURIComponent("[ESP420]plain")}`;
-	SendGetHttp(url, statussuccess, statusfailed);
+
+	const cmd = buildHttpPlainCmd(`${encodeURIComponent("[ESP420]plain")}`);
+	SendGetHttp(cmd, statussuccess, statusfailed);
 }

--- a/www/js/statusdlg.js
+++ b/www/js/statusdlg.js
@@ -99,6 +99,6 @@ function refreshstatus() {
 	text.innerHTML = "";
 	displayNone("status_msg");
 
-	const cmd = buildHttpPlainCmd(`${encodeURIComponent("[ESP420]plain")}`);
+	const cmd = buildHttpPlainCmd("[ESP420]plain");
 	SendGetHttp(cmd, statussuccess, statusfailed);
 }

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -688,8 +688,10 @@ var filename = 'TEST.NC';
 var watchPath = '';
 
 function tabletGetFileList(path) {
-  gCodeFilename = ''
-  SendGetHttp(`/upload?path=${encodeURI(path)}`, files_list_success)
+  // Clear/reset the gCodeFilename
+  gCodeFilename = "";
+  const cmd = `${httpCmd.fileUpload}?path=${encodeURI(path)}`;
+  SendGetHttp(cmd, files_list_success);
 }
 
 function tabletInit() {

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -692,6 +692,11 @@ function tabletGetFileList(path) {
   SendGetHttp(`/upload?path=${encodeURI(path)}`, files_list_success)
 }
 
+const tabletTabActivate = () =>{
+  fullscreenIfMobile();
+  setBottomHeight();
+};
+
 function tabletInit() {
   // put in a timeout to allow things to settle. when they were here at startup ui froze from time to time.
   setTimeout(() => {
@@ -711,10 +716,7 @@ function tabletInit() {
     setJogSelector('mm');
     loadJogDists();
 
-    id("tablettablink").addEventListener("DOMActivate", () => {
-      fullscreenIfMobile();
-      setBottomHeight();
-    }, false);
+    id("tablettablink").addEventListener("DOMActivate", tabletTabActivate, false);
   }, 1000);
 }
 
@@ -1117,15 +1119,17 @@ function homeZ() {
   }, 26000)
 }
 
-document.addEventListener('click', (event) => {
+const tabletDocumentClick = (event) => {
   if (
     !document.getElementById('calibration-popup').contains(event.target) &&
     !document.getElementById('calibrationBTN').contains(event.target) &&
     !document.getElementById('numPad').contains(event.target)
   ) {
-    document.getElementById('calibration-popup').style.display = 'none'
+    document.getElementById('calibration-popup').style.display = 'none';
   }
-})
+};
+
+document.addEventListener('click', tabletDocumentClick);
 
 /* Calibration modal */
 

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -690,7 +690,7 @@ var watchPath = '';
 function tabletGetFileList(path) {
   // Clear/reset the gCodeFilename
   gCodeFilename = "";
-  const cmd = `${httpCmd.fileUpload}?path=${encodeURI(path)}`;
+  const cmd = buildHttpFileCmd({ path: path });
   SendGetHttp(cmd, files_list_success);
 }
 
@@ -1151,7 +1151,7 @@ const onCalibrationButtonsClick = async (command, msg = "") => {
   if (msg) {
     addMessage(msg);
   }
-  sendCommand(command);  
+  sendCommand(command);
 
   //Prints out the index.html version number when test is pressed
   if (command === '$TEST') {

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -838,7 +838,7 @@ function selectFile() {
     gCodeFilename = '';
     files_enter_dir(filename);
   } else {
-    tabletLoadGCodeFile(files_currentPath + filename, file.size);
+    tabletLoadGCodeFile(`${files_currentPath()}${filename}`, file.size);
   }
 }
 function toggleDropdown() {

--- a/www/js/tablet.js
+++ b/www/js/tablet.js
@@ -836,7 +836,7 @@ function selectFile() {
     gCodeFilename = '';
     files_enter_dir(filename);
   } else {
-    tabletLoadGCodeFile(files_currentPath + filename, file.size);
+    tabletLoadGCodeFile(`${files_currentPath()}${filename}`, file.size);
   }
 }
 function toggleDropdown() {

--- a/www/js/updatedlg.js
+++ b/www/js/updatedlg.js
@@ -145,5 +145,5 @@ function updatefailed(error_code, response) {
 	}
 	conErr(error_code, response);
 	update_ongoing = false;
-	SendGetHttp("/updatefw");
+	SendGetHttp(httpCmd.fwUpdate);
 }

--- a/www/js/updatedlg.js
+++ b/www/js/updatedlg.js
@@ -83,8 +83,8 @@ function StartUploadUpdatefile(response) {
 		return;
 	}
 	const files = id("fw-select").files;
+
 	const formData = new FormData();
-	const url = "/updatefw";
 	for (let i = 0; i < files.length; i++) {
 		const file = files[i];
 		const arg = `/${file.name}S`;
@@ -92,15 +92,16 @@ function StartUploadUpdatefile(response) {
 		formData.append(arg, file.size);
 		formData.append("myfile[]", file, `/${file.name}`);
 	}
+
 	displayNone("fw-select_form");
 	displayNone("uploadfw-button");
 	update_ongoing = true;
 	displayBlock("updatemsg");
 	displayBlock("prgfw");
-	if (files.length === 1) current_update_filename = files[0].name;
-	else current_update_filename = "";
+	current_update_filename = files.length === 1 ? files[0].name : "";
 	setHTML("updatemsg", `${translate_text_item("Uploading")} ${current_update_filename}`);
-	SendFileHttp(url, formData, UpdateProgressDisplay, updatesuccess, updatefailed);
+
+	SendFileHttp(httpCmd.fwUpdate, formData, UpdateProgressDisplay, updatesuccess, updatefailed);
 }
 
 function updatesuccess(response) {

--- a/www/js/updatedlg.js
+++ b/www/js/updatedlg.js
@@ -3,6 +3,10 @@
 let update_ongoing = false;
 let current_update_filename = "";
 
+const updateDlgCancel = () => closeUpdateDialog("cancel");
+const updateDlgSelect = () => document.getElementById("fw_select").click();
+const updateDlgFileMouseUp = () => document.getElementById("fw_select_files").click();
+
 /** update dialog */
 const updatedlg = () => {
 	const modal = setactiveModal("updatedlg.html");
@@ -10,19 +14,19 @@ const updatedlg = () => {
 		return;
 	}
 
-	id("updateDlgCancel").addEventListener("click", (event) => closeUpdateDialog("cancel"));
-	id("updateDlgClose").addEventListener("click", (event) => closeUpdateDialog("cancel"));
+	id("updateDlgCancel").addEventListener("click", updateDlgCancel);
+	id("updateDlgClose").addEventListener("click", updateDlgCancel);
 
-	id("fw-select").addEventListener("change", (event) => checkupdatefile());
-	id("fw_select_files").addEventListener("click", (event) => document.getElementById("fw-select").click());
-	id("fw_file_name").addEventListener("mouseup", (event) => document.getElementById("fw_select_files").click());
-	id("uploadfw-button").addEventListener("click", (event) => UploadUpdatefile());
+	id("fw_select").addEventListener("change", checkupdatefile);
+	id("fw_select_files").addEventListener("click", updateDlgSelect);
+	id("fw_file_name").addEventListener("mouseup", updateDlgFileMouseUp);
+	id("uploadfw_button").addEventListener("click", UploadUpdatefile);
 
 	setHTML("fw_file_name", translate_text_item("No file chosen"));
 	displayNone("prgfw");
-	displayNone("uploadfw-button");
+	displayNone("uploadfw_button");
 	setHTML("updatemsg", "");
-	setValue("fw-select", "");
+	setValue("fw_select", "");
 	setHTML("fw_update_dlg_title", translate_text_item("ESP3D Update").replace("ESP3D", "FluidNC"));
 	showModal();
 };
@@ -37,18 +41,18 @@ function closeUpdateDialog(msg) {
 
 function checkupdatefile() {
 	displayNone("updatemsg");
-	const files = id("fw-select").files;
+	const files = id("fw_select").files;
 	switch (files.length) {
 		case 0:
-			displayNone("uploadfw-button");
+			displayNone("uploadfw_button");
 			setHTML("fw_file_name", translate_text_item("No file chosen"));
 			break;
 		case 1:
-			displayBlock("uploadfw-button");
+			displayBlock("uploadfw_button");
 			setHTML("fw_file_name", files[0].name);
 			break;
 		default:
-			displayBlock("uploadfw-button");
+			displayBlock("uploadfw_button");
 			setHTML("fw_file_name", translate_text_item("$n files").replace("$n", files.length));
 			break;
 	}
@@ -82,7 +86,7 @@ function StartUploadUpdatefile(response) {
 		);
 		return;
 	}
-	const files = id("fw-select").files;
+	const files = id("fw_select").files;
 	const formData = new FormData();
 	const url = "/updatefw";
 	for (let i = 0; i < files.length; i++) {
@@ -92,8 +96,8 @@ function StartUploadUpdatefile(response) {
 		formData.append(arg, file.size);
 		formData.append("myfile[]", file, `/${file.name}`);
 	}
-	displayNone("fw-select_form");
-	displayNone("uploadfw-button");
+	displayNone("fw_select_form");
+	displayNone("uploadfw_button");
 	update_ongoing = true;
 	displayBlock("updatemsg");
 	displayBlock("prgfw");
@@ -128,12 +132,12 @@ function updatesuccess(response) {
 }
 
 function updatefailed(error_code, response) {
-	displayBlock("fw-select_form");
+	displayBlock("fw_select_form");
 	displayNone("prgfw");
 	setHTML("fw_file_name", translate_text_item("No file chosen"));
-	displayNone("uploadfw-button");
+	displayNone("uploadfw_button");
 	//setHTML('updatemsg', "");
-	id("fw-select").value = "";
+	id("fw_select").value = "";
 	if (esp_error_code !== 0) {
 		alertdlg(translate_text_item("Error"), stdErrMsg(`(${esp_error_code})`, esp_error_message));
 		setHTML("updatemsg", translate_text_item("Upload failed : ") + esp_error_message);

--- a/www/sub/SPIFFSdlg.html
+++ b/www/sub/SPIFFSdlg.html
@@ -9,23 +9,23 @@
             </h3>
         </div>
         <div class="modal-body">
-            <div class="panel" id="SPIFFS">
+            <div id="SPIFFS" class="panel">
                 <div class="panel-body">
                     <div class="panel-flex-row">
-                        <input type="file" style="display:none" id="SPIFFS-select" name="myfiles[]" multiple />
+                        <input id="SPIFFS_select" type="file" style="display:none" name="myfiles[]" multiple />
                         <table id="SPIFFS-select_form">
                             <tr>
                                 <td>
-                                    <button class="btn btn-info" type="button" id="SPIFFS_select_files" translate>Upload
+                                    <button id="SPIFFS_select_files" class="btn btn-info" type="button" translate>Upload
                                         files</button>
                                 </td>
                                 <td>
-                                    <div class="filetext no_overflow" id="SPIFFS_file_name"></div>
+                                    <div id="SPIFFS_file_name" class="filetext no_overflow"></div>
                                 </td>
                             </tr>
                         </table>
                         &nbsp;
-                        <button class="btn btn-primary btn-svg" type="button" id="SPIFFS_uploadbtn">
+                        <button id="SPIFFS_uploadbtn" class="btn btn-primary btn-svg" type="button">
                             <svg width='1.3em' height='1.2em' viewBox='0 0 1300 1200'>
                                 <g transform='translate(0,1200) scale(1, -1)'>
                                     <path fill='currentColor'
@@ -34,7 +34,7 @@
                                 </g>
                             </svg>
                         </button>
-                        <progress style="display:none;" name="prg" id="SPIFFS_prg" max="100"></progress>
+                        <progress id="SPIFFS_prg" style="display:none;" name="prg" max="100"></progress>
                         &nbsp;
                         <span id="uploadSPIFFSmsg" style="display:none;" translate>Uploading</span>
                     </div>
@@ -71,7 +71,7 @@
                                 <tbody id="SPIFFS_file_list"></tbody>
                             </table>
                         </div>
-                        <div class="panel-footer" id="SPIFFS_status"></div>
+                        <div id="SPIFFS_status" class="panel-footer"></div>
                     </div>
                 </div>
             </div>
@@ -87,7 +87,7 @@
                             <span class=""> &nbsp;&nbsp;</span>
                         </td>
                         <td>
-                            <button class="btn btn-primary" id="refreshSPIFFSbtn">
+                            <button id="refreshSPIFFSbtn" class="btn btn-primary">
                                 <svg width="1.3em" height="1.2em" viewBox="0 0 1300 1200">
                                     <g transform="translate(50,1200) scale(1, -1)">
                                         <path fill="currentColor"

--- a/www/sub/SPIFFSdlg.html
+++ b/www/sub/SPIFFSdlg.html
@@ -13,7 +13,7 @@
                 <div class="panel-body">
                     <div class="panel-flex-row">
                         <input id="SPIFFS_select" type="file" style="display:none" name="myfiles[]" multiple />
-                        <table id="SPIFFS-select_form">
+                        <table id="SPIFFS_select_form">
                             <tr>
                                 <td>
                                     <button id="SPIFFS_select_files" class="btn btn-info" type="button" translate>Upload

--- a/www/sub/files.html
+++ b/www/sub/files.html
@@ -80,7 +80,7 @@
                         <button id="abort_btn" class="btn btn-xs btn-primary" translate>Abort</button>
                         &nbsp;
                         <button id="print_upload_btn" class="btn btn-xs btn-primary" translate>Upload</button>
-                        <input id="files_input_file" type="file" accept=" .g, .gc, .gco, .gcode, .nc, .txt, .G, .GC, .GCO, .GCODE, .NC, .TXT"
+                        <input id="files_input_file" type="file" accept=".g,.gc,.gco,.gcode,.nc,.txt,.G,.GC,.GCO,.GCODE,.NC,.TXT"
                             style="display:none" />
                     </div>
                 </div>

--- a/www/sub/updatedlg.html
+++ b/www/sub/updatedlg.html
@@ -5,16 +5,16 @@
         <div class="modal-header">
             <span id="updateDlgCancel" class="close"><b>&times;</b></span>
             <h3>
-                <div class="modal-title" id="fw_update_dlg_title" translate>FluidNC Firmware Update</div>
+                <div id="fw_update_dlg_title" class="modal-title" translate>FluidNC Firmware Update</div>
             </h3>
         </div>
         <div class="modal-body">
             <table>
                 <tr>
                     <td>
-                        <input id="fw-select" type="file" style='display:none' name="myfiles[]"
+                        <input id="fw_select" type="file" style='display:none' name="myfiles[]"
                             accept=".bin, .bin.gz" />
-                        <table id="fw-select_form">
+                        <table id="fw_select_form">
                             <tr>
                                 <td>
                                     <button id="fw_select_files" class="btn btn-info" type="button" translate>Select
@@ -29,10 +29,10 @@
 
                     <td>&nbsp;</td>
                     <td>
-                        <button id="uploadfw-button" class="btn btn-primary" style='display:none;'
+                        <button id="uploadfw_button" class="btn btn-primary" style='display:none;'
                             translate>Update</button>
                     </td>
-                    <td><progress style='display:none;' name='prgfw' id='prgfw' max='100'></progress></td>
+                    <td><progress id='prgfw' name='prgfw' style='display:none;' max='100'></progress></td>
                     <td>&nbsp;</td>
                     <td>
                         <span id='updatemsg' style='display:none;' translate>Restarting, please wait....</span>


### PR DESCRIPTION
I realised that the haphazard nature of http 'command' (AKA 'url') definitions was a potential for disaster. So this PR make the effort to standardise them all and their usages.

Note that I've changed the term `url` to `cmd` in the codebase wherever I could. This is because what was called `url` was in fact just a 'command'.