### PR TITLE
fix the duplicate page_id declaration

### DIFF
--- a/www/js/config.js
+++ b/www/js/config.js
@@ -26,16 +26,15 @@ function refreshconfig(is_override) {
 }
 
 function config_display_override(display_it) {
-    if (display_it) {
-        displayBlock('config_override_list_content');
-        displayNone('config_main_content');
-        setChecked()
-        id('config_override_file').checked = true;
-    } else {
-        id('config_override_list_content');
-        displayBlock('config_main_content');
-        id('config_main_file').checked = true;
-    }
+	if (display_it) {
+		displayBlock("config_override_list_content");
+		displayNone("config_main_content");
+		setChecked("config_override_file", true);
+	} else {
+		displayNone("config_override_list_content");
+		displayBlock("config_main_content");
+		setChecked("config_main_file", true);
+	}
 }
 
 function getprinterconfig(is_override = false) {

--- a/www/js/httpCmdBuilders.js
+++ b/www/js/httpCmdBuilders.js
@@ -1,7 +1,5 @@
 // Various helper methods for building http commands
 
-var page_id = ""
-
 /** 'Commands' to be sent as the first part of the URL after the host name */
 const httpCmd = {
     command: "/command",
@@ -116,7 +114,7 @@ const buildHttpFileGetCmd = (filename) => `${httpCmd.fileGet}${filename}`;
 /** Build either form of the `command` GET command, fully encoding the supplied `cmd` value.
  * * Note: this includes replacing '#', because '#' is not encoded by `encodeURIComponent`.
  */
-const buildHttpCommandCmd = (cmdType, cmd) => `${httpCmd.command}?${cmdType}=${encodeURIComponent(cmd).replace("#", "%23")}&PAGEID=${page_id}`;
+const buildHttpCommandCmd = (cmdType, cmd) => `${httpCmd.command}?${cmdType}=${encodeURIComponent(cmd).replace("#", "%23")}&PAGEID=${pageID()}`;
 
 /** Build the supplied data into a blob, then a file, ready for inclusion as form data */
 const BuildFormDataFiles = (filename, filedata, options) => {


### PR DESCRIPTION
Yeah, the `buildHttpCommandCmd` should have used `pageID()` declared in `socket.js`