### PR TITLE
Add `CheckForHttpCommLock` back in

### DIFF
--- a/www/js/config.js
+++ b/www/js/config.js
@@ -9,8 +9,7 @@ var is_override_config = false;
 
 
 function refreshconfig(is_override) {
-    if (http_communication_locked) {
-        setHTML('config_status', translate_text_item("Communication locked by another process, retry later."));
+    if (CheckForHttpCommLock()) {
         return;
     }
     is_override_config = false;

--- a/www/js/http.js
+++ b/www/js/http.js
@@ -317,3 +317,11 @@ function ProcessFileHttp(cmd) {
     }
     xmlhttpupload.send(cmd.data);
 }
+
+const CheckForHttpCommLock = () => {
+    if (http_communication_locked) {
+        alertdlg(translate_text_item("Busy..."), translate_text_item("Communications are currently locked, please wait and retry."));
+        console.warn("communication locked");
+    }
+    return http_communication_locked;
+}

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -37,10 +37,9 @@ const CONFIG_TOOLTIPS = {
 }
 
 function refreshSettings(hide_setting_list) {
-  if (http_communication_locked) {
-    setHTML("config_status", translate_text_item("Communication locked by another process, retry later."));
+  if (CheckForHttpCommLock()) {
     return;
-  }
+}
   do_not_build_settings = typeof hide_setting_list == 'undefined' ? false : !hide_setting_list
 
   displayBlock("settings_loader");


### PR DESCRIPTION
Probably a bad merge somewhere, anyway, this function is back in, and its usage extended a little bit.

