### PR TITLE
Tool path displayer update

### DIFF
--- a/www/js/grbl.js
+++ b/www/js/grbl.js
@@ -26,7 +26,7 @@ var last_axis_letter = 'Z';
 
 var axisNames = ['x', 'y', 'z', 'a', 'b', 'c']
 
-var modal = { modes: '', plane: 'G17', units: 'G21', wcs: 'G54', distance: 'G90' }
+var gCodeModal = { modes: '', plane: 'G17', units: 'G21', wcs: 'G54', distance: 'G90' }
 
 let calibrationResults = {}
 
@@ -581,26 +581,26 @@ const modalModes = [
 ]
 
 function grblGetModal(msg) {
-  modal.modes = msg.replace('[GC:', '').replace(']', '')
-  var modes = modal.modes.split(' ')
-  modal.parking = undefined // Otherwise there is no way to turn it off
-  modal.program = '' // Otherwise there is no way to turn it off
+  gCodeModal.modes = msg.replace('[GC:', '').replace(']', '')
+  var modes = gCodeModal.modes.split(' ')
+  gCodeModal.parking = undefined // Otherwise there is no way to turn it off
+  gCodeModal.program = '' // Otherwise there is no way to turn it off
   modes.forEach(function (mode) {
     if (mode == 'M9') {
-      modal.flood = mode
-      modal.mist = mode
+      gCodeModal.flood = mode
+      gCodeModal.mist = mode
     } else {
       if (mode.charAt(0) === 'T') {
-        modal.tool = mode.substring(1)
+        gCodeModal.tool = mode.substring(1)
       } else if (mode.charAt(0) === 'F') {
-        modal.feedrate = mode.substring(1)
+        gCodeModal.feedrate = mode.substring(1)
       } else if (mode.charAt(0) === 'S') {
-        modal.spindle = mode.substring(1)
+        gCodeModal.spindle = mode.substring(1)
       } else {
         modalModes.forEach(function (modeType) {
           modeType.values.forEach(function (s) {
             if (mode == s) {
-              modal[modeType.name] = mode
+              gCodeModal[modeType.name] = mode
             }
           })
         })

--- a/www/js/toolpath-displayer.js
+++ b/www/js/toolpath-displayer.js
@@ -327,12 +327,7 @@ var topView = function() {
     yy = 1.0;
     yz = 0.0;
 }
-var projection = function(wpos) {
-    outpoint = {}
-    outpoint.x = wpos.x * xx + wpos.y * xy + wpos.z * xz;
-    outpoint.y = wpos.x * yx + wpos.y * yy + wpos.z * yz;
-    return outpoint;
-}
+const projection = (wpos) => ({ x: wpos.x * xx + wpos.y * xy + wpos.z * xz, y: wpos.x * yx + wpos.y * yy + wpos.z * yz });
 
 var formatLimit = function(mm) {
     return (tpUnits == 'G20') ? (mm/25.4).toFixed(3)+'"' : mm.toFixed(2)+'mm';
@@ -929,15 +924,22 @@ ToolpathDisplayer.prototype.reDrawTool = function(modal, dpos) {
     }
 }
 
-displayer = new ToolpathDisplayer();
-
 ToolpathDisplayer.prototype.cycleCameraAngle = function(gcode, modal, position) {
     cameraAngle = cameraAngle + 1;
     if(cameraAngle > 4){
         cameraAngle = 0;
     }
 
-    displayer.showToolpath(gcode, modal, position);
+    tpDisplayer().showToolpath(gcode, modal, position);
+}
+
+let displayer = new ToolpathDisplayer();
+
+const tpDisplayer = () => {
+	if (!displayer) {
+		displayer = new ToolpathDisplayer();
+	}
+	return displayer;
 }
 
 /** Expects a simple array with 3 elements, and converts it to an xyz object */
@@ -947,13 +949,13 @@ const arrayToXYZ = (arr) => {
 
 const updateGcodeViewerAngle = () => {
 	const gcode = getValue("tablettab_gcode");
-	tpDisplayer().cycleCameraAngle(gcode, arrayToXYZ(WPOS()));
+	tpDisplayer().cycleCameraAngle(gcode, gCodeModal, arrayToXYZ(WPOS));
 };
 
 canvas.addEventListener("mouseup", updateGcodeViewerAngle); 
 var refreshGcode = function() {
     const gcode = getValue("tablettab_gcode");
-    displayer.showToolpath(gcode, WPOS, MPOS, cameraAngle);
+    tpDisplayer().showToolpath(gcode, WPOS, MPOS, cameraAngle);
 }
 
 // document.getElementById("small-toolpath").addEventListener("mouseup", updateGcodeViewerAngle); 


### PR DESCRIPTION
3 changes:

1. Change the name of the `modal` variable in `grbl.js` to `gCodeModal`, and its usages in `tablet.js` and `toolpath-displayer.js` - especially important in `tablet.js` as it uses `modal` to mean both the GCode modal, and the calibration and config modals. With that, the term `modal` now most commonly means a modal dialog, and the only time it means a GCode modal is when it is being specifically passed as one to a function.
2. Change the `displayer` variable to a get/init function `tpDisplayer()` - this is the main fix. It ensures that the (now) underlying `displayer` variable is always initialised properly.
3. Replaced `WPOS()` (getter/setter in my bun code), back to the old `WPOS` variable (AKA we hope you get the right thing)