### PR TITLE
Generic-ish handling of maslow config stuff

### DIFF
--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -17,185 +17,213 @@ const MaslowErrMsgKeyValueSuffix = "This is probably a programming error\nKey-Va
 
 /** Perform maslow specific-ish info message handling */
 const maslowInfoMsgHandling = (msg) => {
-    if (msg.startsWith('MINFO: ')) {
-        maslowStatus = JSON.parse(msg.substring(7));
-        return true;
-    }
+	if (msg.startsWith("MINFO: ")) {
+		maslowStatus = JSON.parse(msg.substring(7));
+		return true;
+	}
 
-    if (msg.startsWith('[MSG:INFO: Heartbeat')) {
-        lastHeartBeatTime = new Date().getTime();
-        return true;
-    }
+	if (msg.startsWith("[MSG:INFO: Heartbeat")) {
+		lastHeartBeatTime = new Date().getTime();
+		return true;
+	}
 
-    //Catch the calibration complete message and alert the user
-    if (msg.startsWith('[MSG:INFO: Calibration complete')) {
-        alert('Calibration complete. You do not need to do calibration ever again unless your frame changes size. You might want to store a backup of your maslow.yaml file in case you need to restore it later.');
-        return true;
-    }
+	//Catch the calibration complete message and alert the user
+	if (msg.startsWith("[MSG:INFO: Calibration complete")) {
+		alert(
+			"Calibration complete. You do not need to do calibration ever again unless your frame changes size. You might want to store a backup of your maslow.yaml file in case you need to restore it later.",
+		);
+		return true;
+	}
 
-    return false;
-}
+	return false;
+};
 
 /** Perform maslow specific-ish error message handling */
 const maslowErrorMsgHandling = (msg) => {
-    if (!msg.startsWith("error:")) {
-        // Nothing to see here - move along
-        return "";
-    }
+	if (!msg.startsWith("error:")) {
+		// Nothing to see here - move along
+		return "";
+	}
 
-    // And extra information for certain error codes
-    const msgExtra = {
-        "8": " - Command requires idle state. Unlock machine?",
-        "152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Turning off and back on again can often fix this issue.",
-        "153": " - Configuration is invalid. ESP32 probably did a panic reset. Config changes cannot be saved. Try restarting",
-    };
+	// And extra information for certain error codes
+	const msgExtra = {
+		"8": " - Command requires idle state. Unlock machine?",
+		"152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Turning off and back on again can often fix this issue.",
+		"153": " - Configuration is invalid. ESP32 probably did a panic reset. Config changes cannot be saved. Try restarting",
+	};
 
-    return `${msg}${msgExtra[msg.split(":")[1]] || ""}`;
+	return `${msg}${msgExtra[msg.split(":")[1]] || ""}`;
 }
+
+/** Is the machine orientation 'vertical' (the default) */
+const isVert = (value) => value === "horizontal" ? "false" : "true";
+/** What orientation is the machine? */
+const vertIs = (value) => value === "false" ? "horizontal" : "vertical";
+
+const cfgDef = {
+	vertical: { name: "machineOrientation", type: "A", fnVal: isVert, fnDisp: vertIs },
+	calibration_grid_size: { name: "gridSize", type: "A" },
+	calibration_grid_width_mm_X: { name: "gridWidth", type: "A" },
+	calibration_grid_height_mm_Y: { name: "gridHeight", type: "A" },
+	Retract_Current_Threshold: { name: "retractionForce", type: "A" },
+	Calibration_Current_Threshold: { name: "calibrationForce", type: "A" },
+	Acceptable_Calibration_Threshold: { name: "acceptableCalibrationThreshold", type: "A" },
+	Extend_Dist: { name: "extendDist", type: "A" },
+	beltEndExtension: { name: "beltEndExtension", type: "A" },
+	armLength: { name: "armLength", type: "A" },
+	trX: { name: "tr.x", type: "D" },
+	trY: { name: "tr.y", type: "D" },
+	trZ: { name: "tr.z", type: "D" },
+	tlX: { name: "tl.x", type: "D" },
+	tlY: { name: "tl.y", type: "D" },
+	tlZ: { name: "tl.z", type: "D" },
+	brX: { name: "br.x", type: "D" },
+	brY: { name: "br.y", type: "Null" },
+	brZ: { name: "br.z", type: "D" },
+	blX: { name: "bl.x", type: "Null" },
+	blY: { name: "bl.y", type: "Null" },
+	blZ: { name: "bl.z", type: "D" },
+};
 
 /** Handle Maslow specific configuration messages
  * These would have all started with `$/Maslow_` which is expected to have been stripped away before calling this function
  */
 const maslowMsgHandling = (msg) => {
-    const keyValue = msg.split("=");
-    const errMsgSuffix = `${MaslowErrMsgKeyValueSuffix}${msg}`;
-    if (keyValue.length != 2) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgKeyValueCantUse} ${errMsgSuffix}`);
-    }
-    const key = keyValue[0] || "";
-    const value = (keyValue[1] || "").trim();
-    if (!key) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgNoKey} ${errMsgSuffix}`);
-    }
-    if (!value) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgNoValue} ${errMsgSuffix}`);
-    }
+	const keyValue = msg.split("=");
+	const errMsgSuffix = `${MaslowErrMsgKeyValueSuffix}${msg}`;
+	if (keyValue.length !== 2) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgKeyValueCantUse} ${errMsgSuffix}`);
+	}
+	const key = keyValue[0] || "";
+	const value = (keyValue[1] || "").trim();
+	if (!key) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgNoKey} ${errMsgSuffix}`);
+	}
+	if (!value) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgNoValue} ${errMsgSuffix}`);
+	}
 
-    const stdAction = (id, value) => {
-        setValue(id, value);
-        loadedValues[id] = value;
-    }
-    const stdDimensionAction = (value) => parseFloat(value);
-    const nullAction = () => { };
+	const stdAction = (id, value) => {
+		const val = ("fnDisp" in cfgVal && typeof cfgVal.fnDisp === "function") ? cfgVal.fnDisp(value) : value;
+		setValue(id, val);
+		loadedValues(id, value);
+	};
 
-    const msgExtra = {
-        "calibration_grid_size": (value) => stdAction("gridSize", value),
-        "calibration_grid_width_mm_X": (value) => stdAction("gridWidth", value),
-        "calibration_grid_height_mm_Y": (value) => stdAction("gridHeight", value),
-        "Retract_Current_Threshold": (value) => stdAction("retractionForce", value),
-        "vertical": (value) => stdAction("machineOrientation", value === "false" ? "horizontal" : "vertical"),
-        "Extend_Dist": (value) => stdAction("extendDist", value),
-        "trZ": (value) => { initialGuess.tr.z = stdDimensionAction(value) },
-        "tlX": (value) => { initialGuess.tl.x = stdDimensionAction(value) },
-        "tlY": (value) => { initialGuess.tl.y = stdDimensionAction(value) },
-        "tlZ": (value) => { initialGuess.tl.z = stdDimensionAction(value) },
-        "brX": (value) => { initialGuess.br.x = stdDimensionAction(value) },
-        "brY": (value) => nullAction(),
-        "brZ": (value) => { initialGuess.br.z = stdDimensionAction(value) },
-        "blX": (value) => nullAction(),
-        "blY": (value) => nullAction(),
-        "blZ": (value) => { initialGuess.bl.z = stdDimensionAction(value) },
-        "Acceptable_Calibration_Threshold": (value) => { acceptableCalibrationThreshold = stdDimensionAction(value) },
-    }
-    const action = msgExtra[key] || "";
-    if (!action) {
-        return maslowErrorMsgHandling(`error: Could not find key for value in reference table. ${errMsgSuffix}`);
-    }
-    action(value);
+	const stdDimensionAction = (value) => Number.parseFloat(value);
 
-    // Success - return an empty string
-    return "";
+	const cfgVal = cfgDef[key];
+	if (typeof cfgVal !== "object") {
+		return maslowErrorMsgHandling(`error: Could not find key '${key}' in the reference table. ${errMsgSuffix}`);
+	}
+	switch (cfgVal.type) {
+		case "A":
+			stdAction(cfgVal.name, value);
+			break;
+		case "D": {
+			let dimEnt = initialGuess;
+			if (!cfgVal.name) {
+				// Well this is dangerous - so let's not do anything we'll regret very quickly
+				return maslowErrorMsgHandling(`error: No 'name' value specified for '${key}' in the reference table. ${errMsgSuffix}`);
+			}
+			// Traverse through to the required entity
+			cfgVal.name.split(".").forEach((namePart) => {
+				if (!(namePart in dimEnt)) {
+					dimEnt[namePart] = null;
+				}
+				dimEnt = dimEnt[namePart];
+			});
+			dimEnt = stdDimensionAction(value);
+		}
+			break;
+		default:
+			// do nothing - a 'null' action
+			break;
+	}
+
+	// Success - return an empty string
+	return "";
 }
 
 const checkHomed = () => {
-    if (!maslowStatus.homed) {
-        const err_msg = `${M} does not know belt lengths. Please retract and extend before continuing.`;
-        alert(err_msg);
+	if (!maslowStatus.homed) {
+		const err_msg = `${M} does not know belt lengths. Please retract and extend before continuing.`;
+		alert(err_msg);
 
-        // Write to the console too, in case the system alerts are not visible
-        const msgWindow = id('messages');
-        if (msgWindow) {
-            msgWindow.textContent = `${msgWindow.textContent}\n${err_msg}`;
-            msgWindow.scrollTop = msgWindow.scrollHeight;
-        }
-    }
+		// Write to the console too, in case the system alerts are not visible
+		const msgWindow = id('messages');
+		if (msgWindow) {
+			msgWindow.textContent = `${msgWindow.textContent}\n${err_msg}`;
+			msgWindow.scrollTop = msgWindow.scrollHeight;
+		}
+	}
 
-    return maslowStatus.homed;
+	return maslowStatus.homed;
 }
 
 /** Short hand convenience call to SendPrinterCommand with some preset values.
  * Uses the global function get_position, which is also a SendPrinterCommand with presets
  */
 const sendCommand = (cmd) => {
-    SendPrinterCommand(cmd, true, get_Position);
+	SendPrinterCommand(cmd, true, get_Position);
 }
 
 // The following functions are all defined as global functions, and are used by tablettab.html and other places
 // They rely on the global function SendPrinterCommand defined in printercmd.js
 
+/** Get all of the config (not corner) keys in the confiiguration definition */
+const allConfigKeys = () => Object.keys(cfgDef).filter((key) => cfgDef[key].type === "A");
+
 /** Used to populate the config popup when it loads */
-function loadConfigValues() {
-    SendPrinterCommand(`$/${M}_vertical`);
-    SendPrinterCommand(`$/${M}_calibration_grid_width_mm_X`);
-    SendPrinterCommand(`$/${M}_calibration_grid_height_mm_Y`);
-    SendPrinterCommand(`$/${M}_calibration_grid_size`);
-    SendPrinterCommand(`$/${M}_Retract_Current_Threshold`);
-    SendPrinterCommand(`$/${M}_trX`);
-    SendPrinterCommand(`$/${M}_trY`);
-    SendPrinterCommand(`$/${M}_Acceptable_Calibration_Threshold`);
-    SendPrinterCommand(`$/${M}_Extend_Dist`);
-}
+const loadConfigValues = () => {
+	// biome-ignore lint/complexity/noForEach: <explanation>
+	allConfigKeys().forEach((key) => {
+		const cmd = `$/${M}_${key}`;
+		SendPrinterCommand(cmd);
+	});
+};
 
 /** Load all of the corner values */
-function loadCornerValues() {
-    SendPrinterCommand(`$/${M}_tlX`);
-    SendPrinterCommand(`$/${M}_tlY`);
-    SendPrinterCommand(`$/${M}_trX`);
-    SendPrinterCommand(`$/${M}_trY`);
-    SendPrinterCommand(`$/${M}_brX`);
-}
+const loadCornerValues = () => {
+	// biome-ignore lint/complexity/noForEach: <explanation>
+	Object.keys(cfgDef).filter((key) => cfgDef[key].type === "D").forEach((key) => {
+		const cmd = `$/${M}_${key}`;
+		SendPrinterCommand(cmd);
+	});
+};
 
-/** Save the Maslow configuration values */
-function saveConfigValues() {
-    let gridWidth = getValue('gridWidth');
-    let gridHeight = getValue('gridHeight');
-    let gridSize = getValue('gridSize');
-    let retractionForce = getValue('retractionForce');
-    let machineOrientation = getValue('machineOrientation');
-    let extendDist = getValue('extendDist');
+const saveConfigValues = () => {
+	// Get all of the config data as entered, and as already loaded
+	allConfigKeys().forEach((key) => {
+		const cfgVal = cfgDef[key];
+		cfgVal.val = getValue(cfgVal.name);
+		cfgVal.loadedVal = loadedValues(cfgVal.name);
+	});
 
-    var gridSpacingWidth = gridWidth / (gridSize - 1);
-    var gridSpacingHeight = gridHeight / (gridSize - 1);
+	const gridSpacingWidth = cfgDef.calibration_grid_width_mm_X.val / (cfgDef.calibration_grid_size.val - 1);
+	const gridSpacingHeight = cfgDef.calibration_grid_height_mm_Y.val / (cfgDef.calibration_grid_size.val - 1);
 
-    //If the grid spacing is going to be more than 200 don't save the values
-    if (gridSpacingWidth > 260 || gridSpacingHeight > 260) {
-        alert('Grid spacing is too large. Please reduce the grid size or increase the number of points.');
-        return;
-    }
+	//If the grid spacing is going to be more than 200 don't save the values
+	if (gridSpacingWidth > 260 || gridSpacingHeight > 260) {
+		alert("Grid spacing is too large. Please reduce the grid size or increase the number of points.");
+		return;
+	}
 
-    if (gridWidth != loadedValues['gridWidth']) {
-        sendCommand(`$/${M}_calibration_grid_width_mm_X=${gridWidth}`);
-    }
-    if (gridHeight != loadedValues['gridHeight']) {
-        sendCommand(`$/${M}_calibration_grid_height_mm_Y=${gridHeight}`);
-    }
-    if (gridSize != loadedValues['gridSize']) {
-        sendCommand(`$/${M}_calibration_grid_size=${gridSize}`);
-    }
-    if (retractionForce != loadedValues['retractionForce']) {
-        sendCommand(`$/${M}_Retract_Current_Threshold=${retractionForce}`);
-    }
-    if (machineOrientation != loadedValues['machineOrientation']) {
-        sendCommand(`$/${M}_vertical=${machineOrientation === 'horizontal' ? 'false' : 'true'}`);
-    }
-    if (extendDist != loadedValues['extendDist']) {
-        sendCommand(`$/${M}_Extend_Dist=${extendDist}`);
-    }
+	// Save the individual values
+	allConfigKeys().forEach((key) => {
+		const cfgVal = cfgDef[key];
+		const value = typeof cfgVal.val === "undefined"
+			? cfgVal.loadedVal
+			: ("fnVal" in cfgVal && typeof cfgVal.fnVal === "function") ? cfgVal.fnVal(cfgVal.val) : cfgVal.val;
+		if (value !== cfgVal.loadedVal) {
+			const cmd = `$/${M}_${key}=${value}`;
+			sendCommand(cmd);
+		}
+	});
 
-    refreshSettings(current_setting_filter);
-    saveMaslowYaml();
-    loadCornerValues();
+	refreshSettings(current_setting_filter);
+	saveMaslowYaml();
+	loadCornerValues();
 
-    hideModal('configuration-popup');
+	hideModal('configuration-popup');
 }
 


### PR DESCRIPTION
Uses one place in the front-end code for defining maslow config variables. With generic-ish handlers to process the definitions and just do whatever is required.

No need to keep several places in this code in-sync with each other, just set things up in the config definition once (to match what's in fluidNC) and you're good to go.