### PR TITLE
Handle JSON.parse failures

### DIFF
--- a/www/js/grbl.js
+++ b/www/js/grbl.js
@@ -644,9 +644,13 @@ function grblHandleMessage(msg) {
     const validJsonMSG = msg
       .replace(/(\b(?:bl|br|tr|tl)\b):/g, '"$1":')
       .replace('CLBM:', '')
-      .replace(/,]$/, ']')
-    const measurements = JSON.parse(validJsonMSG)
-    handleCalibrationData(measurements)
+      .replace(/,]$/, ']');
+    try {
+      const measurements = JSON.parse(validJsonMSG);
+      handleCalibrationData(measurements);
+    } catch (error) {
+      console.error("Parsing the GRBL `CLBM` message failed, the calibration data has not been 'handled'. This is probably a programmer error.");
+    }
   }
   if (msg.startsWith('<')) {
     grblProcessStatus(msg)

--- a/www/js/logindlg.js
+++ b/www/js/logindlg.js
@@ -22,9 +22,19 @@ const logindlg = (closefunc, check_first = false) => {
 	}
 };
 
+const parseResponse = (response_text, action = "") => {
+	let response = {};
+	try {
+		response = JSON.parse(response_text);
+	} catch (error) {
+		console.error(`Parsing the response from the '${action}' failed. This is probably a programmer error.`);
+	}
+	return response;
+}
+
 function checkloginsuccess(response_text) {
-	const response = JSON.parse(response_text);
-	if (typeof response.authentication_lvl !== "undefined") {
+	const response = parseResponse(response_text, "check for login success");
+	if ("authentication_lvl" in response && typeof response.authentication_lvl !== "undefined") {
 		if (response.authentication_lvl !== "guest") {
 			if (typeof response.authentication_lvl !== "undefined") {
 				setHTML(
@@ -53,11 +63,9 @@ function login_password_OnKeyUp(event) {
 }
 
 function loginfailed(error_code, response_text) {
-	const response = JSON.parse(response_text);
-	setHTML(
-		"login_title",
-		translate_text_item(response.status || "Identification invalid!"),
-	);
+	const response = parseResponse(response_text, "failed login attempt");
+
+	setHTML("login_title", translate_text_item(response.status || "Identification invalid!"));
 	conErr(error_code, response_text);
 	displayBlock("login_content");
 	displayNone("login_loader");
@@ -68,12 +76,9 @@ function loginfailed(error_code, response_text) {
 }
 
 function loginsuccess(response_text) {
-	const response = JSON.parse(response_text);
-	if (typeof response.authentication_lvl !== "undefined") {
-		setHTML(
-			"current_auth_level",
-			`(${translate_text_item(response.authentication_lvl)})`,
-		);
+	const response = parseResponse(response_text, "login success");
+	if ("authentication_lvl" in response && typeof response.authentication_lvl !== "undefined") {
+		setHTML("current_auth_level", `(${translate_text_item(response.authentication_lvl)})`);
 	}
 	displayNone("login_loader");
 	displayBlock("logout_menu");

--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -17,117 +17,121 @@ const MaslowErrMsgKeyValueSuffix = "This is probably a programming error\nKey-Va
 
 /** Perform maslow specific-ish info message handling */
 const maslowInfoMsgHandling = (msg) => {
-    if (msg.startsWith('MINFO: ')) {
-        maslowStatus = JSON.parse(msg.substring(7));
-        return true;
-    }
+	if (msg.startsWith('MINFO: ')) {
+		try {
+			maslowStatus = JSON.parse(msg.substring(7));
+		} catch (error) {
+			console.error("Parsing the 'MINFO' message failed, the maslow status has not been changed. This is probably a programmer error.");
+		}
+		return true;
+	}
 
-    if (msg.startsWith('[MSG:INFO: Heartbeat')) {
-        lastHeartBeatTime = new Date().getTime();
-        return true;
-    }
+	if (msg.startsWith('[MSG:INFO: Heartbeat')) {
+		lastHeartBeatTime = new Date().getTime();
+		return true;
+	}
 
-    //Catch the calibration complete message and alert the user
-    if (msg.startsWith('[MSG:INFO: Calibration complete')) {
-        alert('Calibration complete. You do not need to do calibration ever again unless your frame changes size. You might want to store a backup of your maslow.yaml file in case you need to restore it later.');
-        return true;
-    }
+	//Catch the calibration complete message and alert the user
+	if (msg.startsWith('[MSG:INFO: Calibration complete')) {
+		alert('Calibration complete. You do not need to do calibration ever again unless your frame changes size. You might want to store a backup of your maslow.yaml file in case you need to restore it later.');
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 /** Perform maslow specific-ish error message handling */
 const maslowErrorMsgHandling = (msg) => {
-    if (!msg.startsWith("error:")) {
-        // Nothing to see here - move along
-        return "";
-    }
+	if (!msg.startsWith("error:")) {
+		// Nothing to see here - move along
+		return "";
+	}
 
-    // And extra information for certain error codes
-    const msgExtra = {
-        "8": " - Command requires idle state. Unlock machine?",
-        "152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Turning off and back on again can often fix this issue.",
-        "153": " - Configuration is invalid. ESP32 probably did a panic reset. Config changes cannot be saved. Try restarting",
-    };
+	// And extra information for certain error codes
+	const msgExtra = {
+		"8": " - Command requires idle state. Unlock machine?",
+		"152": " - Configuration is invalid. Maslow.yaml file may be corrupt. Turning off and back on again can often fix this issue.",
+		"153": " - Configuration is invalid. ESP32 probably did a panic reset. Config changes cannot be saved. Try restarting",
+	};
 
-    return `${msg}${msgExtra[msg.split(":")[1]] || ""}`;
+	return `${msg}${msgExtra[msg.split(":")[1]] || ""}`;
 }
 
 /** Handle Maslow specific configuration messages
  * These would have all started with `$/Maslow_` which is expected to have been stripped away before calling this function
  */
 const maslowMsgHandling = (msg) => {
-    const keyValue = msg.split("=");
-    const errMsgSuffix = `${MaslowErrMsgKeyValueSuffix}${msg}`;
-    if (keyValue.length != 2) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgKeyValueCantUse} ${errMsgSuffix}`);
-    }
-    const key = keyValue[0] || "";
-    const value = (keyValue[1] || "").trim();
-    if (!key) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgNoKey} ${errMsgSuffix}`);
-    }
-    if (!value) {
-        return maslowErrorMsgHandling(`${MaslowErrMsgNoValue} ${errMsgSuffix}`);
-    }
+	const keyValue = msg.split("=");
+	const errMsgSuffix = `${MaslowErrMsgKeyValueSuffix}${msg}`;
+	if (keyValue.length != 2) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgKeyValueCantUse} ${errMsgSuffix}`);
+	}
+	const key = keyValue[0] || "";
+	const value = (keyValue[1] || "").trim();
+	if (!key) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgNoKey} ${errMsgSuffix}`);
+	}
+	if (!value) {
+		return maslowErrorMsgHandling(`${MaslowErrMsgNoValue} ${errMsgSuffix}`);
+	}
 
-    const stdAction = (id, value) => {
-        setValue(id, value);
-        loadedValues[id] = value;
-    }
-    const stdDimensionAction = (value) => parseFloat(value);
-    const nullAction = () => { };
+	const stdAction = (id, value) => {
+		setValue(id, value);
+		loadedValues[id] = value;
+	}
+	const stdDimensionAction = (value) => parseFloat(value);
+	const nullAction = () => { };
 
-    const msgExtra = {
-        "calibration_grid_size": (value) => stdAction("gridSize", value),
-        "calibration_grid_width_mm_X": (value) => stdAction("gridWidth", value),
-        "calibration_grid_height_mm_Y": (value) => stdAction("gridHeight", value),
-        "Retract_Current_Threshold": (value) => stdAction("retractionForce", value),
-        "vertical": (value) => stdAction("machineOrientation", value === "false" ? "horizontal" : "vertical"),
-        "Extend_Dist": (value) => stdAction("extendDist", value),
-        "trZ": (value) => { initialGuess.tr.z = stdDimensionAction(value) },
-        "tlX": (value) => { initialGuess.tl.x = stdDimensionAction(value) },
-        "tlY": (value) => { initialGuess.tl.y = stdDimensionAction(value) },
-        "tlZ": (value) => { initialGuess.tl.z = stdDimensionAction(value) },
-        "brX": (value) => { initialGuess.br.x = stdDimensionAction(value) },
-        "brY": (value) => nullAction(),
-        "brZ": (value) => { initialGuess.br.z = stdDimensionAction(value) },
-        "blX": (value) => nullAction(),
-        "blY": (value) => nullAction(),
-        "blZ": (value) => { initialGuess.bl.z = stdDimensionAction(value) },
-        "Acceptable_Calibration_Threshold": (value) => { acceptableCalibrationThreshold = stdDimensionAction(value) },
-    }
-    const action = msgExtra[key] || "";
-    if (!action) {
-        return maslowErrorMsgHandling(`error: Could not find key for value in reference table. ${errMsgSuffix}`);
-    }
-    action(value);
+	const msgExtra = {
+		"calibration_grid_size": (value) => stdAction("gridSize", value),
+		"calibration_grid_width_mm_X": (value) => stdAction("gridWidth", value),
+		"calibration_grid_height_mm_Y": (value) => stdAction("gridHeight", value),
+		"Retract_Current_Threshold": (value) => stdAction("retractionForce", value),
+		"vertical": (value) => stdAction("machineOrientation", value === "false" ? "horizontal" : "vertical"),
+		"Extend_Dist": (value) => stdAction("extendDist", value),
+		"trZ": (value) => { initialGuess.tr.z = stdDimensionAction(value) },
+		"tlX": (value) => { initialGuess.tl.x = stdDimensionAction(value) },
+		"tlY": (value) => { initialGuess.tl.y = stdDimensionAction(value) },
+		"tlZ": (value) => { initialGuess.tl.z = stdDimensionAction(value) },
+		"brX": (value) => { initialGuess.br.x = stdDimensionAction(value) },
+		"brY": (value) => nullAction(),
+		"brZ": (value) => { initialGuess.br.z = stdDimensionAction(value) },
+		"blX": (value) => nullAction(),
+		"blY": (value) => nullAction(),
+		"blZ": (value) => { initialGuess.bl.z = stdDimensionAction(value) },
+		"Acceptable_Calibration_Threshold": (value) => { acceptableCalibrationThreshold = stdDimensionAction(value) },
+	}
+	const action = msgExtra[key] || "";
+	if (!action) {
+		return maslowErrorMsgHandling(`error: Could not find key for value in reference table. ${errMsgSuffix}`);
+	}
+	action(value);
 
-    // Success - return an empty string
-    return "";
+	// Success - return an empty string
+	return "";
 }
 
 const checkHomed = () => {
-    if (!maslowStatus.homed) {
-        const err_msg = `${M} does not know belt lengths. Please retract and extend before continuing.`;
-        alert(err_msg);
+	if (!maslowStatus.homed) {
+		const err_msg = `${M} does not know belt lengths. Please retract and extend before continuing.`;
+		alert(err_msg);
 
-        // Write to the console too, in case the system alerts are not visible
-        const msgWindow = id('messages');
-        if (msgWindow) {
-            msgWindow.textContent = `${msgWindow.textContent}\n${err_msg}`;
-            msgWindow.scrollTop = msgWindow.scrollHeight;
-        }
-    }
+		// Write to the console too, in case the system alerts are not visible
+		const msgWindow = id('messages');
+		if (msgWindow) {
+			msgWindow.textContent = `${msgWindow.textContent}\n${err_msg}`;
+			msgWindow.scrollTop = msgWindow.scrollHeight;
+		}
+	}
 
-    return maslowStatus.homed;
+	return maslowStatus.homed;
 }
 
 /** Short hand convenience call to SendPrinterCommand with some preset values.
  * Uses the global function get_position, which is also a SendPrinterCommand with presets
  */
 const sendCommand = (cmd) => {
-    SendPrinterCommand(cmd, true, get_Position);
+	SendPrinterCommand(cmd, true, get_Position);
 }
 
 // The following functions are all defined as global functions, and are used by tablettab.html and other places
@@ -135,67 +139,67 @@ const sendCommand = (cmd) => {
 
 /** Used to populate the config popup when it loads */
 function loadConfigValues() {
-    SendPrinterCommand(`$/${M}_vertical`);
-    SendPrinterCommand(`$/${M}_calibration_grid_width_mm_X`);
-    SendPrinterCommand(`$/${M}_calibration_grid_height_mm_Y`);
-    SendPrinterCommand(`$/${M}_calibration_grid_size`);
-    SendPrinterCommand(`$/${M}_Retract_Current_Threshold`);
-    SendPrinterCommand(`$/${M}_trX`);
-    SendPrinterCommand(`$/${M}_trY`);
-    SendPrinterCommand(`$/${M}_Acceptable_Calibration_Threshold`);
-    SendPrinterCommand(`$/${M}_Extend_Dist`);
+	SendPrinterCommand(`$/${M}_vertical`);
+	SendPrinterCommand(`$/${M}_calibration_grid_width_mm_X`);
+	SendPrinterCommand(`$/${M}_calibration_grid_height_mm_Y`);
+	SendPrinterCommand(`$/${M}_calibration_grid_size`);
+	SendPrinterCommand(`$/${M}_Retract_Current_Threshold`);
+	SendPrinterCommand(`$/${M}_trX`);
+	SendPrinterCommand(`$/${M}_trY`);
+	SendPrinterCommand(`$/${M}_Acceptable_Calibration_Threshold`);
+	SendPrinterCommand(`$/${M}_Extend_Dist`);
 }
 
 /** Load all of the corner values */
 function loadCornerValues() {
-    SendPrinterCommand(`$/${M}_tlX`);
-    SendPrinterCommand(`$/${M}_tlY`);
-    SendPrinterCommand(`$/${M}_trX`);
-    SendPrinterCommand(`$/${M}_trY`);
-    SendPrinterCommand(`$/${M}_brX`);
+	SendPrinterCommand(`$/${M}_tlX`);
+	SendPrinterCommand(`$/${M}_tlY`);
+	SendPrinterCommand(`$/${M}_trX`);
+	SendPrinterCommand(`$/${M}_trY`);
+	SendPrinterCommand(`$/${M}_brX`);
 }
 
 /** Save the Maslow configuration values */
 function saveConfigValues() {
-    let gridWidth = getValue('gridWidth');
-    let gridHeight = getValue('gridHeight');
-    let gridSize = getValue('gridSize');
-    let retractionForce = getValue('retractionForce');
-    let machineOrientation = getValue('machineOrientation');
-    let extendDist = getValue('extendDist');
+	let gridWidth = getValue('gridWidth');
+	let gridHeight = getValue('gridHeight');
+	let gridSize = getValue('gridSize');
+	let retractionForce = getValue('retractionForce');
+	let machineOrientation = getValue('machineOrientation');
+	let extendDist = getValue('extendDist');
 
-    var gridSpacingWidth = gridWidth / (gridSize - 1);
-    var gridSpacingHeight = gridHeight / (gridSize - 1);
+	var gridSpacingWidth = gridWidth / (gridSize - 1);
+	var gridSpacingHeight = gridHeight / (gridSize - 1);
 
-    //If the grid spacing is going to be more than 200 don't save the values
-    if (gridSpacingWidth > 260 || gridSpacingHeight > 260) {
-        alert('Grid spacing is too large. Please reduce the grid size or increase the number of points.');
-        return;
-    }
+	//If the grid spacing is going to be more than 200 don't save the values
+	if (gridSpacingWidth > 260 || gridSpacingHeight > 260) {
+		alert('Grid spacing is too large. Please reduce the grid size or increase the number of points.');
+		return;
+	}
 
-    if (gridWidth != loadedValues['gridWidth']) {
-        sendCommand(`$/${M}_calibration_grid_width_mm_X=${gridWidth}`);
-    }
-    if (gridHeight != loadedValues['gridHeight']) {
-        sendCommand(`$/${M}_calibration_grid_height_mm_Y=${gridHeight}`);
-    }
-    if (gridSize != loadedValues['gridSize']) {
-        sendCommand(`$/${M}_calibration_grid_size=${gridSize}`);
-    }
-    if (retractionForce != loadedValues['retractionForce']) {
-        sendCommand(`$/${M}_Retract_Current_Threshold=${retractionForce}`);
-    }
-    if (machineOrientation != loadedValues['machineOrientation']) {
-        sendCommand(`$/${M}_vertical=${machineOrientation === 'horizontal' ? 'false' : 'true'}`);
-    }
-    if (extendDist != loadedValues['extendDist']) {
-        sendCommand(`$/${M}_Extend_Dist=${extendDist}`);
-    }
+	if (gridWidth != loadedValues['gridWidth']) {
+		sendCommand(`$/${M}_calibration_grid_width_mm_X=${gridWidth}`);
+	}
+	if (gridHeight != loadedValues['gridHeight']) {
+		sendCommand(`$/${M}_calibration_grid_height_mm_Y=${gridHeight}`);
+	}
+	if (gridSize != loadedValues['gridSize']) {
+		sendCommand(`$/${M}_calibration_grid_size=${gridSize}`);
+	}
+	if (retractionForce != loadedValues['retractionForce']) {
+		sendCommand(`$/${M}_Retract_Current_Threshold=${retractionForce}`);
+	}
+	if (machineOrientation != loadedValues['machineOrientation']) {
+		sendCommand(`$/${M}_vertical=${machineOrientation === 'horizontal' ? 'false' : 'true'}`);
+	}
+	if (extendDist != loadedValues['extendDist']) {
+		sendCommand(`$/${M}_Extend_Dist=${extendDist}`);
+	}
 
-    refreshSettings(current_setting_filter);
-    saveMaslowYaml();
-    loadCornerValues();
+	refreshSettings(current_setting_filter);
+	saveMaslowYaml();
+	loadCornerValues();
 
-    hideModal('configuration-popup');
+	hideModal('configuration-popup');
 }
 

--- a/www/js/passworddlg.js
+++ b/www/js/passworddlg.js
@@ -46,8 +46,14 @@ function checkpassword() {
 }
 
 function ChangePasswordfailed(error_code, response_text) {
-	const response = JSON.parse(response_text);
-	if (typeof response.status !== "undefined") {
+	let response = {};
+	try {
+		response = JSON.parse(response_text);
+	} catch (error) {
+		console.error("Change password failed. And then processing the response message about the failure also failed. This is probably a programmer error.");
+	}
+
+	if ("status" in response && typeof response.status !== "undefined") {
 		setHTML("password_content", translate_text_item(response.status));
 	}
 	conErr(error_code, response_text || "");

--- a/www/js/preferencesdlg.js
+++ b/www/js/preferencesdlg.js
@@ -552,6 +552,7 @@ function SavePreferences(current_preferences) {
     if (CheckForHttpCommLock()) {
         return;
     }
+
     console.log("save prefs");
     if (((typeof (current_preferences) !== 'undefined') && !current_preferences) || (typeof (current_preferences) == 'undefined')) {
         if (!Checkvalues("preferences_autoReport_Interval") ||
@@ -578,7 +579,7 @@ function SavePreferences(current_preferences) {
         saveprefs.push(`"enable_DHT":"${id('enable_DHT').checked}"`);
 
         saveprefs.push(`"enable_camera":"${id('show_camera_panel').checked}"`);
-        saveprefs.push(`"auto_load_camera":"${id('autoload_camera_panel').checked}`);
+        saveprefs.push(`"auto_load_camera":"${id('autoload_camera_panel').checked}"`);
         saveprefs.push(`"camera_address":"${HTMLEncode(getValue('preferences_camera_webaddress') || "")}"`);
 
         saveprefs.push(`"enable_control_panel":"${id('show_control_panel').checked}"`);
@@ -614,8 +615,15 @@ function SavePreferences(current_preferences) {
         saveprefs.push(`"enable_commands_panel":"${id('show_commands_panel').checked}"`);
         saveprefs.push(`"enable_autoscroll":"${id('preferences_autoscroll').checked}"`);
         saveprefs.push(`"enable_verbose_mode":"${id('preferences_verbose_mode').checked}"}]`);
-        preferenceslist = JSON.parse(saveprefs.join(","));
+        try {
+            preferenceslist = JSON.parse(saveprefs.join(","));
+        } catch (error) {
+            console.error("There was an error preparing the preferences before saving them. The preferences have not been saved. This is probably a programmer error.");
+            console.error(error);
+            return;
+        }
     }
+
     const file = BuildFormDataFiles(preferences_file_name, [JSON.stringify(preferenceslist, null, " ")], { type: 'application/json' });
     var formData = new FormData();
     formData.append('path', '/');


### PR DESCRIPTION
First this PR fixes a single character typo in `preferencesdls.js` which would cause a `JSON.parse` failure.

But that got me thinking about checking whether all the calls to `JSON.parse` were in try catch blocks. Answer, nope, not all.

So this PR fixes that, even though several fixes are in parts of the code base that we don't currently go.

`JSON.parse` failures can often occur after a programmer has been fixing something in some other part of the system, which then ends up breaking when parsing it somewhere else fails. Always wrapping `JSON.parse` in try catch blocks is a great safety measure for saving programmer sanity.