### PR TITLE
Adds a config option for the force used during the calibration process

### DIFF
--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -232,6 +232,14 @@
             <input id="retractionForce" type="text" class="calibration-modal-input">
           </div>
         </div>
+        <div class="grid-container">
+          <div class="input-row">
+            <label for="calibrationForce" class="input-label">Calibration Force</label>
+          </div>
+          <div class="input-row">
+            <input id="calibrationForce" type="text" class="calibration-modal-input">
+          </div>
+        </div>
         <hr style="border-top: 1px dashed;">
         <div class="input-row">
           <button id="tablettab_config_save" type="button" class="calibration-modal-button">Save</button>


### PR DESCRIPTION
## Description

Version 1.0+ drops the default retraction force down to 900 which seems pretty low sometimes. This makes it easier for folks to change that setting without having to dig too deep into the menus. 

<img width="669" alt="image" src="https://github.com/user-attachments/assets/9fddb541-890f-459e-86eb-4294fac35baf" />


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have throughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new calibration input within the configuration dialog, allowing users to easily enter calibration force values while maintaining a consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->