### PR TITLE
Swap out btn for link

### DIFF
--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -48,7 +48,9 @@ function closeSPIFFSDialog(msg) {
 const buildTable = (content) => `<table>${content}</table>`;
 const buildTr = (content) => `<tr>${content}</tr>`;
 
-function SPIFFSselect_dir(directoryname) {
+function SPIFFSselect_dir(event) {
+	event.stopPropagation();
+	const directoryname = event.currentTarget.dataset.path;
 	const needTraillingSlash = directoryname.endsWith("/") ? "" : "/";
 	SPIFFS_currentpath = directoryname + needTraillingSlash;
 	SPIFFSSendCommand("list", "all");
@@ -58,7 +60,7 @@ const AddActionHandlers = (actions) => {
 	for (const action of actions) {
 		const elem = id(action.id);
 		if (elem) {
-			elem.addEventListener("click", (event) => action.method(action.path));
+			elem.addEventListener("click", action.method);
 		}
 	}
 }
@@ -74,13 +76,13 @@ const SPIFFSnavbar = () => {
 	const bIdD = "SPIFFS_btn_dir_";
 
 	const spanRoot = "<span class='tooltip-text'>Go to root directory</span>";
-	let content = `<td class='tooltip'>${spanRoot}<button id="${bIdD}_root" class="btn btn-primary">/</button></td>`;
-	actions.push({ id: `${bIdD}_root`, method: SPIFFSselect_dir, path: "/" });
+	let content = `<td class='tooltip'>${spanRoot}<button id="${bIdD}_root" data-path="/" class="btn btn-primary">/</button></td>`;
+	actions.push({ id: `${bIdD}_root`, method: SPIFFSselect_dir });
 	while (nb < tlist.length - 1) {
 		path += `${tlist[nb]}/`;
 		const bId = `${bIdD}${nb}`;
-		content += `<td><button id=${bId} class="btn btn-link">${tlist[nb]}</button></td><td>/</td>`;
-		actions.push({ id: bId, method: SPIFFSselect_dir, path: path });
+		content += `<td><button id=${bId} data-path="${path}" class="btn btn-link">${tlist[nb]}</button></td><td>/</td>`;
+		actions.push({ id: bId, method: SPIFFSselect_dir });
 		nb++;
 	}
 
@@ -105,13 +107,15 @@ function processSPIFFSDelete(answer) {
 	SPIFFS_currentfile = "";
 }
 
-function SPIFFSDelete(filename) {
-	SPIFFS_currentfile = filename;
+function SPIFFSDelete(event) {
+	event.stopPropagation();
+	SPIFFS_currentfile = event.currentTarget.dataset.path;
 	confirmdlg(translate_text_item("Please Confirm"), translate_text_item("Confirm deletion of file: ") + filename, processSPIFFSDelete);
 }
 
-function SPIFFSDeleteDir(filename) {
-	SPIFFS_currentfile = filename;
+function SPIFFSDeleteDir(event) {
+	event.stopPropagation();
+	SPIFFS_currentfile = event.currentTarget.dataset.path;
 	confirmdlg(translate_text_item("Please Confirm"), translate_text_item("Confirm deletion of directory: ") + filename, processSPIFFSDeleteDir);
 }
 
@@ -122,8 +126,9 @@ function processSPIFFSDeleteDir(answer) {
 	SPIFFS_currentfile = "";
 }
 
-function SPIFFSRename(filename) {
-	old_file_name = filename;
+function SPIFFSRename(event) {
+	event.stopPropagation();
+	old_file_name = event.currentTarget.dataset.path;
 	inputdlg(translate_text_item("New file name"), translate_text_item("Name:"), processSPIFFSRename, old_file_name);
 }
 
@@ -182,8 +187,8 @@ function SPIFFSfailed(error_code, response) {
 	conErr(error_code, response);
 }
 
-function SPIFFSbutton(btnId, btnClass, icon) {
-	const btnContent = `<button id="${btnId}" class="btn ${btnClass} btn-xs" style='padding: 5px 5px 0px 5px;'>${get_icon_svg(icon)}</button>`;
+function SPIFFSbutton(btnId, btnClass, icon, path) {
+	const btnContent = `<button id="${btnId}" data-path="${path}" class="btn ${btnClass} btn-xs" style='padding: 5px 5px 0px 5px;'>${get_icon_svg(icon)}</button>`;
 	return `<td width='0%' style='vertical-align:middle'>${btnContent}</td>`;
 }
 
@@ -203,8 +208,9 @@ const buildSPIFFSTotalBar = (jsonresponse) => {
 	return content;
 };
 
-const upDirAndRelist = (previouspath) => {
-	SPIFFS_currentpath = previouspath;
+const upDirAndRelist = (event) => {
+	event.stopPropagation();
+	SPIFFS_currentpath = event.currentTarget.dataset.path;
 	SPIFFSSendCommand("list", "all");
 };
 
@@ -217,8 +223,8 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
 		const pos = SPIFFS_currentpath.lastIndexOf("/", SPIFFS_currentpath.length - 2);
 		const previouspath = SPIFFS_currentpath.slice(0, pos + 1);
 		const rowId = "SPIFFS_row_up_dir";
-		content += `<tr id="${rowId}" style="cursor:pointer;"><td >${get_icon_svg("level-up")}</td><td colspan='4'> Up..</td></tr>`;
-		actions.push({ id: rowId, method: upDirAndRelist, path: previouspath });
+		content += `<tr id="${rowId}" data-path="${previouspath}" style="cursor:pointer;"><td >${get_icon_svg("level-up")}</td><td colspan='4'> Up..</td></tr>`;
+		actions.push({ id: rowId, method: upDirAndRelist });
 	}
 	jsonresponse.files.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 
@@ -236,12 +242,12 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
 		filecontent += `<td width='100%' style='vertical-align:middle'>${filename}</td>`;
 		filecontent += `<td nowrap  style='vertical-align:middle; text-align:right'>${filesize}</td>`;
 		filecontent += SPIFFSanchor(`${bIdF}download_${i}`, "btn-default", "download", pathname + filename);
-		filecontent += SPIFFSbutton(`${bIdF}delete_${i}`, "btn-danger", "trash");
-		filecontent += SPIFFSbutton(`${bIdF}rename_${i}`, "btn-default", "wrench");
+		filecontent += SPIFFSbutton(`${bIdF}delete_${i}`, "btn-danger", "trash", filename);
+		filecontent += SPIFFSbutton(`${bIdF}rename_${i}`, "btn-default", "wrench", filename);
 		content += buildTr(filecontent);
 
-		actions.push({ id: `${bIdF}delete_${i}`, method: SPIFFSDelete, path: filename });
-		actions.push({ id: `${bIdF}rename_${i}`, method: SPIFFSRename, path: filename });
+		actions.push({ id: `${bIdF}delete_${i}`, method: SPIFFSDelete });
+		actions.push({ id: `${bIdF}rename_${i}`, method: SPIFFSRename });
 	}
 
 	//then display directories
@@ -251,18 +257,18 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
 			continue;
 		}
 		const dirname = jsonresponse.files[i].name;
-		const selectDirBtn = `<button id="${bIdD}select_${i}" class="btn btn-link">${dirname}</button>`;
-		actions.push({ id: `${bIdD}select_${i}`, method: SPIFFSselect_dir, path: `${SPIFFS_currentpath}${dirname}` });
+		const selectDirBtn = `<button id="${bIdD}select_${i}" data-path="${SPIFFS_currentpath}${dirname}" class="btn btn-link">${dirname}</button>`;
+		actions.push({ id: `${bIdD}select_${i}`, method: SPIFFSselect_dir });
 		let dircontent = `<td style='vertical-align:middle ; color:#5BC0DE'>${get_icon_svg("folder-close")}</td>`;
 		dircontent += `<td width='100%' style='vertical-align:middle'>${selectDirBtn}</td>`;
 		dircontent += "<td nowrap style='vertical-align:middle'></td>"; // No size field
 		dircontent += "<td></td>"; // Spacer for nonexistent download button
-		dircontent += SPIFFSbutton(`${bIdD}delete_${i}`, "btn-danger", "trash");
-		dircontent += SPIFFSbutton(`${bIdD}rename_${i}`, "btn-default", "wrench");
+		dircontent += SPIFFSbutton(`${bIdD}delete_${i}`, "btn-danger", "trash", dirname);
+		dircontent += SPIFFSbutton(`${bIdD}rename_${i}`, "btn-default", "wrench", dirname);
 		content += buildTr(dircontent);
 
-		actions.push({ id: `${bIdD}delete_${i}`, method: SPIFFSDeleteDir, path: dirname });
-		actions.push({ id: `${bIdD}rename_${i}`, method: SPIFFSRename, path: dirname });
+		actions.push({ id: `${bIdD}delete_${i}`, method: SPIFFSDeleteDir });
+		actions.push({ id: `${bIdD}rename_${i}`, method: SPIFFSRename });
 	}
 
 	setHTML("SPIFFS_file_list", content);

--- a/www/js/SPIFFSdlg.js
+++ b/www/js/SPIFFSdlg.js
@@ -98,16 +98,6 @@ function processSPIFFS_Createdir(answer) {
 	}
 }
 
-function SPIFFSDownload(url) {
-	console.info(`Preparing to download ${url}`);
-	const anchor = document.createElement("a");
-	anchor.href = url;
-	anchor.download = url;
-	document.body.appendChild(anchor);
-	anchor.click();
-	document.body.removeChild(anchor);
-}
-
 function processSPIFFSDelete(answer) {
 	if (answer === "yes") {
 		SPIFFSSendCommand("delete", SPIFFS_currentfile);
@@ -197,6 +187,11 @@ function SPIFFSbutton(btnId, btnClass, icon) {
 	return `<td width='0%' style='vertical-align:middle'>${btnContent}</td>`;
 }
 
+const SPIFFSanchor = (btnId, btnClass, icon, url) => {
+	const aContent = `<a id="${btnId}" class="btn ${btnClass} btn-xs" href="${url}" download="${url}" style='padding: 5px 5px 0px 5px;'>${get_icon_svg(icon)}</a>`;
+	return `<td width='0%' style='vertical-align:middle'>${aContent}</td>`;
+}
+
 const buildSPIFFSTotalBar = (jsonresponse) => {
 	let content = `${translate_text_item("Total:")} ${jsonresponse.total}`;
 	content += `&nbsp;&nbsp;|&nbsp;&nbsp;${translate_text_item("Used:")} ${jsonresponse.used}&nbsp;`;
@@ -240,12 +235,11 @@ function SPIFFSdispatchfilestatus(jsonresponse) {
 		// filecontent += "<td width='100%' style='vertical-align:middle'><a href=\"" + pathname + filename + "\" target=_blank download><button  class=\"btn btn-link no_overflow\">" + filename + "</button></a></td>"
 		filecontent += `<td width='100%' style='vertical-align:middle'>${filename}</td>`;
 		filecontent += `<td nowrap  style='vertical-align:middle; text-align:right'>${filesize}</td>`;
-		filecontent += SPIFFSbutton(`${bIdF}download_${i}`, "btn-default", "download");
+		filecontent += SPIFFSanchor(`${bIdF}download_${i}`, "btn-default", "download", pathname + filename);
 		filecontent += SPIFFSbutton(`${bIdF}delete_${i}`, "btn-danger", "trash");
 		filecontent += SPIFFSbutton(`${bIdF}rename_${i}`, "btn-default", "wrench");
 		content += buildTr(filecontent);
 
-		actions.push({ id: `${bIdF}download_${i}`, method: SPIFFSDownload, path: pathname + filename });
 		actions.push({ id: `${bIdF}delete_${i}`, method: SPIFFSDelete, path: filename });
 		actions.push({ id: `${bIdF}rename_${i}`, method: SPIFFSRename, path: filename });
 	}

--- a/www/js/files.js
+++ b/www/js/files.js
@@ -139,6 +139,14 @@ function formatFileSize(size) {
 	return `${nSize} B`;
 }
 
+const FileButton = (btnId, btnClass, icon, index) =>{
+	return `<button id="${btnId}" data-index="${index}" class="btn btn-xs ${btnClass}" style='padding-top: 4px;'>${get_icon_svg(icon, "1em", "1em")}</button>`;
+}
+
+const FileAnchor = (btnId, btnClass, icon, url) => {
+	return `<a id="${btnId}" class="btn btn-xs ${btnClass}" href="${url}" download="${url}" style='padding-top: 4px;'>${get_icon_svg(icon)}</a>`;
+}
+
 function files_build_file_line(index, actions) {
 	let content = "";
 	const entry = files_file_list[index];
@@ -146,7 +154,7 @@ function files_build_file_line(index, actions) {
 	if ((files_filter_sd_list && entry.isprintable) || !files_filter_sd_list) {
 		const fliId = `filelist_${index}`;
 		const clickStyle = is_clickable ? " style='cursor:pointer;'" : "";
-		content += `<li id='${fliId}' class='list-group-item list-group-hover'${clickStyle}>`;
+		content += `<li id='${fliId}' data-index='${index}' class='list-group-item list-group-hover' ${clickStyle}>`;
 		content += "<div class='row'>";
 		content += "<div class='col-md-5 col-sm-5 no_overflow'>";
 		content += "<table><tr>";
@@ -155,7 +163,7 @@ function files_build_file_line(index, actions) {
 		content += "</tr></table>";
 		content += "</div>";
 		if (is_clickable) {
-			actions.push({ id: fliId, method: files_click_file, index: index });
+			actions.push({ id: fliId, method: files_click_file });
 		}
 		let sizecol = "col-md-2 col-sm-2 filesize";
 		let timecol = "col-md-2 col-sm-2";
@@ -168,26 +176,23 @@ function files_build_file_line(index, actions) {
 		const entrySize = entry.isdir ? "" : formatFileSize(entry.size);
 		content += `<div class='${sizecol}'>${entrySize}</div>`;
 
-		const btnPad = "style='padding-top: 4px;'";
-		const btnCls = "class='btn btn-xs btn-default'";
 		content += `<div class='${timecol}'>${entry.datetime}</div>`;
 		content += `<div class='${iconcol}'>`;
 		content += "<div class='pull-right'>";
 		if (entry.isprintable) {
-			content += `<button id='${fliId}_print_btn' ${btnCls} ${btnPad}>${get_icon_svg("play", "1em", "1em")}</button>`;
-			actions.push({ id: `${fliId}_print_btn`, method: files_print, index: index });
+			content += FileButton(`${fliId}_print_btn`, "btn-default", "play", index);
+			actions.push({ id: `${fliId}_print_btn`, method: files_print });
 		}
 		content += "&nbsp;";
 		if (!entry.isdir) {
-			content += `<button id='${fliId}_download_btn' ${btnCls} ${btnPad}>${get_icon_svg("download", "1em", "1em")}</button>`;
-			actions.push({ id: `${fliId}_download_btn`, method: files_download, index: index });
+			content += FileAnchor(`${fliId}_download_btn`, "btn-default", "download", buildFileHref(index));			
 		}
 		if (files_showdeletebutton(index)) {
-			content += `<button id='${fliId}_delete_btn' class='btn btn-xs btn-danger' ${btnPad}>${get_icon_svg("trash", "1em", "1em")}</button>`;
-			actions.push({ id: `${fliId}_delete_btn`, method: files_delete, index: index });
+			content += FileButton(`${fliId}_delete_btn`, "btn-danger", "trash", index);
+			actions.push({ id: `${fliId}_delete_btn`, method: files_delete });
 		}
-		content += `<button id='${fliId}_rename_btn' ${btnCls} ${btnPad}>${get_icon_svg("wrench", "1em", "1em")}</button>`;
-		actions.push({ id: `${fliId}_rename_btn`, method: files_rename, index: index });
+		content += FileButton(`${fliId}_rename_btn`, "btn-default", "wrench", index);
+		actions.push({ id: `${fliId}_rename_btn`, method: files_rename });
 		content += "</div>";
 		content += "</div>";
 		content += "</div>";
@@ -203,7 +208,11 @@ function tabletSelectGCodeFile(filename) {
 	option.selected = true;
 }
 
-function files_print(index) {
+const getEventIndex = (event) => Number.parseInt(event.currentTarget.dataset.index);
+
+function files_print(event) {
+	event.stopPropagation();
+	const index = getEventIndex(event);
 	const file = files_file_list[index];
 	const path = `${files_currentPath()}${file.name}`;
 	tabletSelectGCodeFile(file.name);
@@ -238,7 +247,9 @@ function files_create_dir(name) {
 	SendGetHttp(cmd, files_list_success, files_list_failed);
 }
 
-function files_delete(index) {
+function files_delete(event) {
+	event.stopPropagation();
+	const index = getEventIndex(event);
 	files_current_file_index = index;
 	let msg = translate_text_item("Confirm deletion of directory: ");
 	if (!files_file_list[index].isdir) {
@@ -272,7 +283,9 @@ const files_is_clickable = (index) => files_file_list[index].isdir ? true : dire
 const files_enter_dir = (name) => files_refreshFiles(`${files_currentPath()}${name}/`);
 
 let old_file_name;
-function files_rename(index) {
+function files_rename(event) {
+	event.stopPropagation();
+	const index = getEventIndex(event);
 	const entry = files_file_list[index];
 	old_file_name = entry.sdname;
 	inputdlg(translate_text_item("New file name"), translate_text_item("Name:"), process_files_rename, old_file_name);
@@ -291,11 +304,10 @@ function process_files_rename(new_file_name) {
 }
 
 const buildFileHref = (index) => encodeURIComponent(`SD/${files_currentPath()}${files_file_list[index].sdname}`.replace("//", "/"));
-function files_download(index) {
-	//console.log("file on direct SD");
-	window.location.href = buildFileHref(index);
-}
-function files_click_file(index) {
+
+function files_click_file(event) {
+	event.stopPropagation();
+	const index = getEventIndex(event);
 	const entry = files_file_list[index];
 	if (entry.isdir) {
 		files_enter_dir(entry.name);
@@ -508,7 +520,9 @@ function files_directSD_upload_failed(error_code, response) {
 
 const need_up_level = () => files_currentPath() !== "/";
 
-function files_go_levelup() {
+function files_go_levelup(event) {
+	event.stopPropagation();
+
 	const tlist = files_currentPath().split("/");
 	let path = "/";
 	let nb = 1;
@@ -546,7 +560,7 @@ function files_build_display_filelist(displaylist = true) {
 			content += `<li id='${liId}' class='list-group-item list-group-hover' style='cursor:pointer'>`;
 			content += `<span>${get_icon_svg("level-up")}</span>&nbsp;&nbsp;<span translate>Up...</span>`;
 			content += "</li>";
-			actions.push({ id: liId, method: files_go_levelup, index: undefined });
+			actions.push({ id: liId, method: files_go_levelup });
 		}
 		for (let index = 0; index < files_file_list.length; index++) {
 			if (!files_file_list[index].isdir)
@@ -558,12 +572,12 @@ function files_build_display_filelist(displaylist = true) {
 		}
 
 		fileListElem.innerHTML = content;
-		actions.forEach((action) => {
+		for (const action of actions) {
 			const elem = id(action.id);
 			if (elem) {
-				elem.addEventListener("click", (event) => action.method(action.index));
+				elem.addEventListener("click", action.method);
 			}
-		});
+		}
 		displayBlock("files_fileList");
 	}
 


### PR DESCRIPTION
## Description

This swaps out the 'download' button and its associated event handler for a simple anchor link in both files.js and SPIFFSdlg.js file listings.

Fixes # (issue)

It also eliminates the anonymous event handler creation that takes place in these two files, reducing the chances of a potential memory leak.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have thoroughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced interactive elements for file actions, including new controls for downloads.

- **Refactor**
  - Streamlined how user actions are processed, providing a smoother experience when printing, deleting, renaming, and navigating files and directories.
  - Improved the responsiveness of file management interactions with simplified event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->