### PR TITLE
Update fitness failed message

### DIFF
--- a/www/js/calculatesCalibrationStuff.js
+++ b/www/js/calculatesCalibrationStuff.js
@@ -558,7 +558,7 @@ function findMaxFitness(measurements) {
 
     } else { //We have completed the calibration (success or timeout)
       if (1 / bestGuess.fitness < acceptableCalibrationThreshold) {
-        messagesBox.textContent += '\nWARNING FITNESS TOO LOW. DO NOT USE THESE CALIBRATION VALUES!';
+        messagesBox.textContent += '\nCalculated Fitness Too Low. The process will automatically try again.!';
       }
 
       messagesBox.textContent += '\nCalibration values:';


### PR DESCRIPTION
## Description

Updates the message when the calibration process fails due to a low fitness score to make it clear to folks that it should be allowed to try again.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have throughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the warning message shown when calibration fitness is too low to a softer notification, indicating the process will retry automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->