### PR TITLE
Add units and hover test for retraction force valid range

### DIFF
--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -180,7 +180,7 @@
         <hr style="border-top: 1px dashed;">
         <div class="grid-container">
           <div class="input-row">
-            <label for="extendDist" class="input-label">Extend Dist</label>
+            <label for="extendDist" class="input-label">Extend Dist(mm)</label>
           </div>
           <div class="input-row">
             <input id="extendDist" type="text" class="calibration-modal-input">
@@ -227,7 +227,7 @@
           </div>
         </div>
         <hr style="border-top: 1px dashed;">
-        <div class="grid-container">
+        <div class="grid-container" title="Valid Range is 0-2500">
           <div class="input-row">
             <label for="retractionForce" class="input-label">Retraction Force</label>
           </div>
@@ -235,7 +235,7 @@
             <input id="retractionForce" type="text" class="calibration-modal-input">
           </div>
         </div>
-        <div class="grid-container">
+        <div class="grid-container" title="Valid Range is 0-2500">
           <div class="input-row">
             <label for="calibrationForce" class="input-label">Calibration Force</label>
           </div>


### PR DESCRIPTION
## Description

Adds units to the extend dist and hover text to the retraction forces to make it more clear what they do. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have thoroughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the "Extend Dist" label to display the unit "(mm)".
  - Added tooltips specifying the valid range for "Retraction Force" and "Calibration Force" input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->