### PR TITLE
Use machine state as flag for cant move warning

### DIFF
--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -301,8 +301,8 @@ const maslowMsgHandling = (msg) => {
 }
 
 const checkHomed = () => {
-	if (!maslowStatus.homed) {
-		const err_msg = `${M} does not know belt lengths. Please retract and extend before continuing.`;
+	if (maslowStatus.state != 7) { // If the state is not 'ready to cut'
+		const err_msg = `${M} Is not ready to move.`;
 		alert(err_msg);
 
 		// Write to the console too, in case the system alerts are not visible
@@ -313,7 +313,7 @@ const checkHomed = () => {
 		}
 	}
 
-	return maslowStatus.homed;
+	return maslowStatus.state === 7; // Return true if the state is 'ready to cut'
 }
 
 /** Short hand convenience call to SendPrinterCommand with some preset values.

--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -302,7 +302,7 @@ const maslowMsgHandling = (msg) => {
 
 const checkHomed = () => {
 	if (maslowStatus.state != 7) { // If the state is not 'ready to cut'
-		const err_msg = `${M} Is not ready to move.`;
+		const err_msg = `${M} is not ready to move.`;
 		alert(err_msg);
 
 		// Write to the console too, in case the system alerts are not visible
@@ -313,7 +313,7 @@ const checkHomed = () => {
 		}
 	}
 
-	return maslowStatus.state === 7; // Return true if the state is 'ready to cut'
+	return maslowStatus.state == 7; // Return true if the state is 'ready to cut'
 }
 
 /** Short hand convenience call to SendPrinterCommand with some preset values.


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Uses the machine state instead of a homed flag to trigger when the arrow buttons will make the machine move

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have thoroughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
