### PR TITLE
Display correct state while calculating calibration

### DIFF
--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -61,6 +61,17 @@ const updateDynamicButtons = () => {
 	const greenBackground = "#4aa85c"
 	const greyBackground = "#a0a0a0"
 
+	// #define UNKNOWN 0
+	// #define RETRACTING 1
+	// #define RETRACTED 2
+	// #define EXTENDING 3
+	// #define EXTENDEDOUT 4 //Extended is a reserved word
+	// #define TAKING_SLACK 5
+	// #define CALIBRATION_IN_PROGRESS 6
+	// #define READY_TO_CUT 7
+	// #define RELEASE_TENSION 8
+	// #define CALIBRATION_COMPUTING 9
+
 	switch (maslowStatus.state) {
 		case 0: 
 			stateLabel.innerHTML = "State: Unknown";
@@ -143,6 +154,26 @@ const updateDynamicButtons = () => {
 			calibrateButton.style.backgroundColor = greyBackground;
 
 			break;
+		case 8:
+			stateLabel.innerHTML = "State: Releasing Tension";
+
+			retractButton.style.backgroundColor = greyBackground;
+			extendButton.style.backgroundColor = greyBackground;
+			tenseButton.style.backgroundColor = greyBackground;
+			relaxButton.style.backgroundColor = greyBackground;
+			calibrateButton.style.backgroundColor = greyBackground;
+
+			// No buttons are active in this state
+			break;
+		case 9:
+			stateLabel.innerHTML = "State: Calibration Computing";
+			// No buttons are active in this state
+			retractButton.style.backgroundColor = greyBackground;
+			extendButton.style.backgroundColor = greyBackground;
+			tenseButton.style.backgroundColor = greyBackground;
+			relaxButton.style.backgroundColor = greyBackground;
+			calibrateButton.style.backgroundColor = greyBackground;
+			break;
 		default:
 			stateLabel.innerHTML = "State: Unknown";
 
@@ -154,6 +185,8 @@ const updateDynamicButtons = () => {
 			break;
 	}
 }
+
+
 
 
 /** Perform maslow specific-ish info message handling */
@@ -188,7 +221,7 @@ const maslowInfoMsgHandling = (msg) => {
 		if (m) {
 			const state = Number(m[1]);
 			//If the state is in the range of 0-7, update the maslowStatus
-			if (state < 0 || state > 7) {
+			if (state < 0 || state > 9) {
 				console.error("Invalid state received from machine: " + state);
 				return false;
 			}


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Adds correct handling for the new state "Calibration Computing" which the machine enters while the calibration process is running computation which prevents the machine from moving in this state.


Fixes # (issue)

https://github.com/BarbourSmith/FluidNC/issues/204

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have thoroughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
