### PR TITLE
Change 'vertical' to 'upright'

### DIFF
--- a/www/js/maslow.js
+++ b/www/js/maslow.js
@@ -295,13 +295,13 @@ const maslowErrorMsgHandling = (msg) => {
 	return `${msg}${msgExtra[msg.split(":")[1]] || ""}`;
 }
 
-/** Is the machine orientation 'vertical' (the default) */
+/** Is the machine orientation 'upright' (the default) */
 const isVert = (value) => value === "horizontal" ? "false" : "true";
 /** What orientation is the machine? */
-const vertIs = (value) => value === "false" ? "horizontal" : "vertical";
+const vertIs = (value) => value === "false" ? "horizontal" : "upright";
 
 const cfgDef = {
-	vertical: { name: "machineOrientation", type: "A", fnVal: isVert, fnDisp: vertIs },
+	orientation: { name: "machineOrientation", type: "A", fnVal: isVert, fnDisp: vertIs },
 	calibration_grid_size: { name: "gridSize", type: "A" },
 	calibration_grid_width_mm_X: { name: "gridWidth", type: "A" },
 	calibration_grid_height_mm_Y: { name: "gridHeight", type: "A" },

--- a/www/js/settings.js
+++ b/www/js/settings.js
@@ -13,7 +13,7 @@ let current_setting_filter = "nvs";
 var setup_is_done = false;
 let do_not_build_settings = false;
 const CONFIG_TOOLTIPS = {
-  Maslow_vertical: `If the ${M} is oriented horizontally, set this to false`,
+  Maslow_orientation: `Set to true if the ${M} is oriented upright, or false if it is oriented horizontally`,
   Maslow_calibration_offset_X: "mm offset from the edge of the frame, X",
   Maslow_calibration_offset_Y: "mm offset from the edge of the frame, Y",
   Maslow_calibration_size_X: "Number of X points to use in calibration",

--- a/www/js/tests/maslow.test.ts
+++ b/www/js/tests/maslow.test.ts
@@ -60,9 +60,9 @@ describe('maslowMsgHandling', () => {
   });
 
   const orientationActions = [
-    ["vertical", "false", "machineOrientation", "horizontal"],
-    ["vertical", "true", "machineOrientation", "vertical"],
-    ["vertical", "something else", "machineOrientation", "vertical"],
+    ["orientation", "false", "machineOrientation", "horizontal"],
+    ["orientation", "true", "machineOrientation", "upright"],
+    ["orientation", "something else", "machineOrientation", "upright"],
   ];
 
   test.each(orientationActions)("Key %p with value %p sets %p to %p", (key, value, outputValueName, outputValue) => {

--- a/www/sub/tablettab.html
+++ b/www/sub/tablettab.html
@@ -191,7 +191,7 @@
           <div class="input-row">
             <select id="machineOrientation" class="calibration-modal-input">
               <option value="horizontal">Horizontal</option>
-              <option value="vertical">Vertical</option>
+              <option value="upright">Upright</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Description

'Vertical' vs. 'Horizontal' has confused too many Maslow users too many times. Changing 'Vertical' to 'Upright' provides better understanding to users about what they're being told.

Fixes # - So much confusion

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have thoroughly tested this on hardware and these changes do not break any existing functionality. This is important!
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
